### PR TITLE
Refactor SignTransaction and Checkout success screens

### DIFF
--- a/src/components/TransactionSender.vue
+++ b/src/components/TransactionSender.vue
@@ -1,0 +1,101 @@
+<template>
+    <div></div>
+</template>
+
+<script lang="ts">
+import {Component, Emit, Prop, Watch, Vue} from 'vue-property-decorator';
+import {SignTransactionResult} from '../lib/RequestTypes';
+import RpcApi from '../lib/RpcApi';
+import {
+    SignTransactionRequest as KSignTransactionRequest,
+    SignTransactionResult as KSignTransactionResult,
+} from '@nimiq/keyguard-client';
+import {State as RpcState, ResponseStatus} from '@nimiq/rpc';
+import {State} from 'vuex-class';
+import {Static} from '../lib/StaticStore';
+
+@Component({components: {}})
+export default class TransactionSender extends Vue {
+    // tslint:disable-next-line variable-name
+    public static Events = {
+        TRANSACTION_SENT: 'transaction-sent',
+    };
+
+    @State private keyguardResult!: KSignTransactionResult;
+    @Static private rpcState!: RpcState;
+    @Static private keyguardRequest!: any;
+    // Uint8Arrays cannot be stored in SessionStorage, thus the stored request has arrays instead and is
+    // thus not exactly the type KSignTransactionRequest.
+
+    public async send() {
+        // Load web assembly encryption library into browser (if supported)
+        await Nimiq.WasmHelper.doImportBrowser();
+
+        // Configure to use test net for now
+        Nimiq.GenesisConfig.test();
+
+        let tx: Nimiq.Transaction;
+
+        if (
+            (this.keyguardRequest.data && this.keyguardRequest.data.length > 0)
+            || this.keyguardRequest.senderType !== Nimiq.Account.Type.BASIC
+            || this.keyguardRequest.recipientType !== Nimiq.Account.Type.BASIC
+        ) {
+            tx = new Nimiq.ExtendedTransaction(
+                new Nimiq.Address(new Nimiq.SerialBuffer(this.keyguardRequest.sender)),
+                this.keyguardRequest.senderType || Nimiq.Account.Type.BASIC,
+                new Nimiq.Address(new Nimiq.SerialBuffer(this.keyguardRequest.recipient)),
+                this.keyguardRequest.recipientType || Nimiq.Account.Type.BASIC,
+                this.keyguardRequest.value,
+                this.keyguardRequest.fee,
+                this.keyguardRequest.validityStartHeight,
+                this.keyguardRequest.flags || 0,
+                new Nimiq.SerialBuffer(this.keyguardRequest.data || 0),
+                Nimiq.SignatureProof.singleSig(
+                    new Nimiq.PublicKey(this.keyguardResult.publicKey),
+                    new Nimiq.Signature(this.keyguardResult.signature),
+                ).serialize(),
+                this.keyguardRequest.networkId,
+            );
+        } else {
+            tx = new Nimiq.BasicTransaction(
+                new Nimiq.PublicKey(this.keyguardResult.publicKey),
+                new Nimiq.Address(new Nimiq.SerialBuffer(this.keyguardRequest.recipient)),
+                this.keyguardRequest.value,
+                this.keyguardRequest.fee,
+                this.keyguardRequest.validityStartHeight,
+                new Nimiq.Signature(this.keyguardResult.signature),
+                this.keyguardRequest.networkId,
+            );
+        }
+
+        const result: SignTransactionResult = {
+            serializedTx: tx.serialize(),
+
+            sender: tx.sender.toUserFriendlyAddress(),
+            senderType: tx.senderType,
+            senderPubKey: this.keyguardResult.publicKey,
+
+            recipient: tx.recipient.toUserFriendlyAddress(),
+            recipientType: tx.recipientType,
+
+            value: tx.value / 1e5,
+            fee: tx.fee / 1e5,
+            validityStartHeight: tx.validityStartHeight,
+
+            signature: this.keyguardResult.signature,
+
+            extraData: tx.data,
+            flags: tx.flags,
+            networkId: tx.networkId,
+
+            hash: tx.hash().toBase64(),
+        };
+
+        // Forward signing result to original caller window
+        this.rpcState.reply(ResponseStatus.OK, result);
+
+        this.$emit(TransactionSender.Events.TRANSACTION_SENT);
+    }
+}
+</script>

--- a/src/lib/RpcApi.ts
+++ b/src/lib/RpcApi.ts
@@ -96,7 +96,7 @@ export default class RpcApi {
                 result.kind = command;
                 this._store.commit('setKeyguardResult', result);
 
-                this._router.push({name: keyguardResponseRouter[command].resolve});
+                this._router.push({name: keyguardResponseRouter(command, this._staticStore.request!.kind).resolve});
             }, (error, state) => {
                 // Recover state
                 this._recoverState(state);
@@ -104,7 +104,7 @@ export default class RpcApi {
                 // Set result
                 this._store.commit('setKeyguardResult', error);
 
-                this._router.push({name: keyguardResponseRouter[command].reject});
+                this._router.push({name: keyguardResponseRouter(command, this._staticStore.request!.kind).reject});
             });
         }
     }

--- a/src/views/Checkout.vue
+++ b/src/views/Checkout.vue
@@ -13,107 +13,16 @@
 </template>
 
 <script lang="ts">
-import {Component, Emit, Prop, Watch, Vue} from 'vue-property-decorator';
-import {AccountSelector, LoginSelector, PaymentInfoLine, SmallPage} from '@nimiq/vue-components';
-import {
-    RequestType,
-    ParsedCheckoutRequest,
-    ParsedSignTransactionRequest,
-    SignTransactionResult,
-} from '../lib/RequestTypes';
-import {AddressInfo} from '../lib/AddressInfo';
-import {KeyInfo, KeyStorageType} from '../lib/KeyInfo';
-import {State, Mutation, Getter} from 'vuex-class';
-import RpcApi from '../lib/RpcApi';
-import {
-    SignTransactionRequest as KSignTransactionRequest,
-    SignTransactionResult as KSignTransactionResult,
-} from '@nimiq/keyguard-client';
-import {ResponseStatus, State as RpcState} from '@nimiq/rpc';
+import {Component, Emit, Vue} from 'vue-property-decorator';
+import {PaymentInfoLine, SmallPage} from '@nimiq/vue-components';
+import {ParsedCheckoutRequest} from '../lib/RequestTypes';
+import {State as RpcState} from '@nimiq/rpc';
 import {Static} from '../lib/StaticStore';
 
 @Component({components: {PaymentInfoLine, SmallPage}})
 export default class Checkout extends Vue {
-    @State private keyguardResult!: KSignTransactionResult | Error | null;
-
     @Static private rpcState!: RpcState;
-    @Static private request!: ParsedSignTransactionRequest;
-    @Static private keyguardRequest!: any;
-    // Uint8Arrays cannot be stored in SessionStorage, thus the stored request has arrays instead and is
-    // thus not the type KSignTransactionRequest
-
-    @Watch('keyguardResult', {immediate: true})
-    private async onKeyguardResult() {
-        if (this.keyguardResult instanceof Error) {
-            //
-        } else if (this.keyguardResult) {
-            // Load web assembly encryption library into browser (if supported)
-            await Nimiq.WasmHelper.doImportBrowser();
-            // Configure to use test net for now
-            Nimiq.GenesisConfig.test();
-
-            let tx: Nimiq.Transaction;
-
-            if (
-                (this.keyguardRequest.data && this.keyguardRequest.data.length > 0)
-             || this.keyguardRequest.senderType !== Nimiq.Account.Type.BASIC
-             || this.keyguardRequest.recipientType !== Nimiq.Account.Type.BASIC
-            ) {
-                tx = new Nimiq.ExtendedTransaction(
-                    new Nimiq.Address(new Nimiq.SerialBuffer(this.keyguardRequest.sender)),
-                    this.keyguardRequest.senderType || Nimiq.Account.Type.BASIC,
-                    new Nimiq.Address(new Nimiq.SerialBuffer(this.keyguardRequest.recipient)),
-                    this.keyguardRequest.recipientType || Nimiq.Account.Type.BASIC,
-                    this.keyguardRequest.value,
-                    this.keyguardRequest.fee,
-                    this.keyguardRequest.validityStartHeight,
-                    this.keyguardRequest.flags || 0,
-                    new Nimiq.SerialBuffer(this.keyguardRequest.data || 0),
-                    Nimiq.SignatureProof.singleSig(
-                        new Nimiq.PublicKey(this.keyguardResult.publicKey),
-                        new Nimiq.Signature(this.keyguardResult.signature),
-                    ).serialize(),
-                    this.keyguardRequest.networkId,
-                );
-            } else {
-                tx = new Nimiq.BasicTransaction(
-                    new Nimiq.PublicKey(this.keyguardResult.publicKey),
-                    new Nimiq.Address(new Nimiq.SerialBuffer(this.keyguardRequest.recipient)),
-                    this.keyguardRequest.value,
-                    this.keyguardRequest.fee,
-                    this.keyguardRequest.validityStartHeight,
-                    new Nimiq.Signature(this.keyguardResult.signature),
-                    this.keyguardRequest.networkId,
-                );
-            }
-
-            const result: SignTransactionResult = {
-                serializedTx: tx.serialize(),
-
-                sender: tx.sender.toUserFriendlyAddress(),
-                senderType: tx.senderType,
-                senderPubKey: this.keyguardResult.publicKey,
-
-                recipient: tx.recipient.toUserFriendlyAddress(),
-                recipientType: tx.recipientType,
-
-                value: tx.value / 1e5,
-                fee: tx.fee / 1e5,
-                validityStartHeight: tx.validityStartHeight,
-
-                signature: this.keyguardResult.signature,
-
-                extraData: tx.data,
-                flags: tx.flags,
-                networkId: tx.networkId,
-
-                hash: tx.hash().toBase64(),
-            };
-
-            // Forward signing result to original caller window
-            this.rpcState.reply(ResponseStatus.OK, result);
-        }
-    }
+    @Static private request!: ParsedCheckoutRequest;
 
     @Emit()
     private close() {

--- a/src/views/CheckoutOverview.vue
+++ b/src/views/CheckoutOverview.vue
@@ -18,9 +18,9 @@
 
 <script lang="ts">
 import {Component, Emit, Vue} from 'vue-property-decorator';
-import {State, Getter} from 'vuex-class';
+import {Getter} from 'vuex-class';
 import {Amount, Account} from '@nimiq/vue-components';
-import {SignTransactionRequest} from '@nimiq/keyguard-client';
+import {SignTransactionRequest as KSignTransactionRequest} from '@nimiq/keyguard-client';
 import {State as RpcState} from '@nimiq/rpc';
 import {AddressInfo} from '../lib/AddressInfo';
 import {KeyInfo} from '../lib/KeyInfo';
@@ -29,7 +29,7 @@ import RpcApi from '../lib/RpcApi';
 import staticStore, {Static} from '../lib/StaticStore';
 
 @Component({components: {Amount, Account}})
-export default class Checkout extends Vue {
+export default class CheckoutOverview extends Vue {
     @Static private rpcState!: RpcState;
     @Static private request!: ParsedCheckoutRequest;
 
@@ -69,7 +69,7 @@ export default class Checkout extends Vue {
             return;
         }
 
-        const request: SignTransactionRequest = {
+        const request: KSignTransactionRequest = {
             layout: 'checkout',
             shopOrigin: this.rpcState.origin,
             appName: this.request.appName,

--- a/src/views/CheckoutSelectAccount.vue
+++ b/src/views/CheckoutSelectAccount.vue
@@ -26,7 +26,7 @@ import {RequestType} from '../lib/RequestTypes';
 import {State, Mutation} from 'vuex-class';
 
 @Component({components: {AccountSelector, LoginSelector}})
-export default class Checkout extends Vue {
+export default class CheckoutSelectAccount extends Vue {
     @State('keys') private keys!: KeyInfo[];
 
     @Mutation('addKey') private addKey!: (key: KeyInfo) => any;

--- a/src/views/SignTransactionSuccess.vue
+++ b/src/views/SignTransactionSuccess.vue
@@ -1,9 +1,9 @@
 <template>
     <div class="success center">
         <div class="icon-checkmark-circle"></div>
-        <h1>Your payment<br>was successfull!</h1>
+        <h1>Your transaction<br>was successfull!</h1>
         <div style="flex-grow: 1;"></div>
-        <button @click="close" :disabled="!isTxSent">Back to store</button>
+        <button @click="close" :disabled="!isTxSent">Back to {{ request.appName }}</button>
         <TransactionSender ref="txSender"/>
     </div>
 </template>
@@ -11,13 +11,13 @@
 <script lang="ts">
 import {Component, Emit, Vue} from 'vue-property-decorator';
 import TransactionSender from '@/components/TransactionSender.vue';
-// import {RequestType, ParsedCheckoutRequest} from '../lib/RequestTypes';
+import {ParsedSignTransactionRequest} from '../lib/RequestTypes';
 // import {State} from 'vuex-class';
-// import {Static} from '../lib/StaticStore';
+import {Static} from '../lib/StaticStore';
 
 @Component({components: {TransactionSender}})
-export default class CheckoutSuccess extends Vue {
-    // @Static private request!: ParsedCheckoutRequest;
+export default class SignTransactionSuccess extends Vue {
+    @Static private request!: ParsedSignTransactionRequest;
 
     private isTxSent: boolean = false;
 


### PR DESCRIPTION
To enable correct routing when returning from Keyguard and to move transaction creation and sending logic into a shared `TransactionSender` component. This component currently only assembles the transaction and replies it to the RPC client, but will in the future be responsible for relaying the transaction to a server or creating the network consensus to send directly.