### PR TITLE
Rename AccountsManagerClient => AccountsClient

### DIFF
--- a/client/AccountsClient.ts
+++ b/client/AccountsClient.ts
@@ -18,7 +18,7 @@ import {
     // ListResult,
 } from '../src/lib/RequestTypes';
 
-export default class AccountsManagerClient {
+export default class AccountsClient {
     private static readonly DEFAULT_ENDPOINT =
     window.location.origin === 'https://safe-next.nimiq.com' ? 'https://accounts.nimiq.com'
     : window.location.origin === 'https://safe-next.nimiq-testnet.com' ? 'https://accounts.nimiq-testnet.com'
@@ -32,7 +32,7 @@ export default class AccountsManagerClient {
     private readonly _iframeBehavior: IFrameRequestBehavior;
     private readonly _redirectClient: RedirectRpcClient;
 
-    constructor(endpoint: string = AccountsManagerClient.DEFAULT_ENDPOINT, defaultBehavior?: RequestBehavior) {
+    constructor(endpoint: string = AccountsClient.DEFAULT_ENDPOINT, defaultBehavior?: RequestBehavior) {
         this._endpoint = endpoint;
         this._defaultBehavior = defaultBehavior || new PopupRequestBehavior(
             `left=${window.innerWidth / 2 - 500},top=50,width=1000,height=900,location=yes,dependent=yes`);

--- a/client/package.json
+++ b/client/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@nimiq/accounts-manager-client",
+  "name": "@nimiq/accounts-client",
   "version": "0.0.1",
-  "main": "dist/AccountsManagerClient.umd.js",
-  "module": "dist/AccountsManagerClient.es.js",
-  "repository": "https://github.com/nimiq/accounts",
+  "main": "dist/AccountsClient.umd.js",
+  "module": "dist/AccountsClient.es.js",
+  "repository": "https://github.com/nimiq/accounts/tree/master/client",
   "author": "Nimiq Network Ltd.",
   "license": "Apache-2.0",
   "private": false,

--- a/client/rollup.config.js
+++ b/client/rollup.config.js
@@ -4,41 +4,41 @@ import { terser } from "rollup-plugin-terser";
 
 export default [
     {
-        input: 'build/client/AccountsManagerClient.js',
+        input: 'build/client/AccountsClient.js',
         output: {
-            file: 'dist/AccountsManagerClient.umd.js',
+            file: 'dist/AccountsClient.umd.js',
             format: 'umd',
-            name: 'AccountsManagerClient',
+            name: 'AccountsClient',
             globals: { '@nimiq/rpc': 'rpc' }
         },
         external: [ '@nimiq/rpc' ]
     },
     {
-        input: 'build/client/AccountsManagerClient.js',
+        input: 'build/client/AccountsClient.js',
         output: {
-            file: 'dist/AccountsManagerClient.es.js',
+            file: 'dist/AccountsClient.es.js',
             format: 'es',
-            name: 'AccountsManagerClient',
+            name: 'AccountsClient',
             globals: { '@nimiq/rpc': 'rpc' }
         },
         external: [ '@nimiq/rpc' ]
     },
     {
-        input: 'build/client/AccountsManagerClient.js',
+        input: 'build/client/AccountsClient.js',
         output: {
-            file: 'dist/standalone/AccountsManagerClient.umd.js',
+            file: 'dist/standalone/AccountsClient.umd.js',
             format: 'umd',
-            name: 'AccountsManagerClient',
+            name: 'AccountsClient',
             globals: { '@nimiq/rpc': 'rpc' }
         },
         plugins: [ resolve(), terser() ]
     },
     {
-        input: 'build/client/AccountsManagerClient.js',
+        input: 'build/client/AccountsClient.js',
         output: {
-            file: 'dist/standalone/AccountsManagerClient.es.js',
+            file: 'dist/standalone/AccountsClient.es.js',
             format: 'es',
-            name: 'AccountsManagerClient',
+            name: 'AccountsClient',
             globals: { '@nimiq/rpc': 'rpc' }
         },
         plugins: [ resolve(), terser() ]

--- a/demos/Demo.ts
+++ b/demos/Demo.ts
@@ -1,7 +1,7 @@
 /// <reference path="../node_modules/@nimiq/core-types/Nimiq.d.ts" />
 
 import * as Rpc from '@nimiq/rpc';
-import AccountsManagerClient from '../client/AccountsManagerClient';
+import AccountsClient from '../client/AccountsClient';
 import {
     RequestType,
     SignupRequest, SignupResult,
@@ -26,7 +26,7 @@ class Demo {
 
         const demo = new Demo('http://localhost:8000');
 
-        const client = new AccountsManagerClient('http://localhost:8080');
+        const client = new AccountsClient('http://localhost:8080');
         client.on(RequestType.CHECKOUT, (result: SignTransactionResult, state: Rpc.State) => {
             console.log('AccountsManager result', result);
             console.log('State', state);


### PR DESCRIPTION
Since "Accounts Manager" is an invented name, and the repo and subdomain is only called `accounts`, why not stay with that and name the client for it the `AccountsClient`.

This PR renames the classes and build files to be `AccountsClient.es.js` etc...