### PR TITLE
Adapt design to styleguide

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "@nimiq/keyguard-client": "^0.0.19",
         "@nimiq/network-client": "^0.0.9",
         "@nimiq/rpc": "^0.0.11",
-        "@nimiq/style": "^0.2.1",
+        "@nimiq/style": "^0.3.2",
         "@nimiq/vue-components": "https://github.com/nimiq/vue-components.git#build/accounts",
         "vue": "^2.5.16",
         "vue-class-component": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "@nimiq/keyguard-client": "^0.0.19",
         "@nimiq/network-client": "^0.0.9",
         "@nimiq/rpc": "^0.0.11",
-        "@nimiq/style": "^0.3.2",
+        "@nimiq/style": "^0.3.3",
         "@nimiq/vue-components": "https://github.com/nimiq/vue-components.git#build/accounts",
         "vue": "^2.5.16",
         "vue-class-component": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "@nimiq/keyguard-client": "^0.0.19",
         "@nimiq/network-client": "^0.0.9",
         "@nimiq/rpc": "^0.0.11",
+        "@nimiq/style": "^0.2.1",
         "@nimiq/vue-components": "https://github.com/nimiq/vue-components.git#build/accounts",
         "vue": "^2.5.16",
         "vue-class-component": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "@nimiq/keyguard-client": "^0.0.19",
         "@nimiq/network-client": "^0.0.9",
         "@nimiq/rpc": "^0.0.11",
-        "@nimiq/style": "^0.3.3",
+        "@nimiq/style": "^0.3.4",
         "@nimiq/vue-components": "https://github.com/nimiq/vue-components.git#build/accounts",
         "vue": "^2.5.16",
         "vue-class-component": "^6.0.0",

--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,9 @@
     <script src="https://cdn.nimiq-testnet.com/web-offline.js"></script>
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <title>Nimiq Accounts Manager</title>
+
+    <link href="https://fonts.googleapis.com/css?family=Muli:400,600,700" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Fira+Mono&text=0123456789ABCDEFGHJKLMNPQRSTUVXY" rel="stylesheet">
   </head>
   <body>
     <noscript>

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,6 +2,7 @@
     <div id="app">
         <header class="logo-container">
             <div class="logo icon-logo">
+                <span class="nq-icon nimiq-logo"></span>
                 Nimiq
             </div>
         </header>
@@ -18,6 +19,10 @@
 <script lang="ts">
 import { Component, Watch, Vue } from 'vue-property-decorator';
 import { State } from 'vuex-class';
+
+import '@nimiq/style/nimiq-style.min.css';
+import '@nimiq/style/nimiq-style-icons.min.css';
+import '@nimiq/vue-components/dist/NimiqVueComponents.css';
 
 @Component
 export default class App extends Vue {
@@ -51,20 +56,8 @@ export default class App extends Vue {
 </script>
 
 <style>
-    @import '../node_modules/@nimiq/vue-components/dist/NimiqVueComponents.css';
-
     html, body {
-        margin: 0;
         height: 100%;
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
-    }
-
-    html {
-        background: linear-gradient(55deg, #2462dc, #a83df6);
-        background-size: cover;
-        background-attachment: fixed;
-        font-size: 8px;
-        --nimiq-size: 8px; /* For @nimiq/vue-components */
     }
 
     @media (max-width: 450px) {
@@ -72,10 +65,6 @@ export default class App extends Vue {
             font-size: 7px;
             --nimiq-size: 7px; /* For @nimiq/vue-components */
         }
-    }
-
-    body {
-        font-size: 2.25rem;
     }
 
     .logo-container {
@@ -87,22 +76,25 @@ export default class App extends Vue {
     .logo {
         height: 3.625rem;
         box-sizing: border-box;
-        padding-left: 6rem;
+        /* padding-left: 6rem; */
         font-size: 2.125rem;
         font-weight: 600;
         text-transform: uppercase;
         letter-spacing: 0.077em;
         display: inline-flex;
         align-items: center;
-        color: white;
+        color: var(--nimiq-blue);
         z-index: 1;
         text-decoration: none;
         user-select: none;
         -webkit-tap-highlight-color: transparent;
         outline: none !important;
-        background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="499" height="440"><path fill="%23FFC107" fill-rule="evenodd" d="M389 21c-6-12-23-21-36-21H145c-13 0-29 9-36 21L5 199c-6 11-6 30 0 41l104 178c7 12 23 21 36 21h208c14 0 30-9 36-21l104-178c7-11 7-30 0-41L389 21zM273 347v42h-39v-40c-24-3-52-13-70-30l25-39c21 15 38 23 57 23 23 0 33-9 33-28 0-40-106-39-106-111 0-38 23-65 61-73V51h39v40c25 3 44 16 59 32l-29 33c-15-13-27-20-44-20-19 0-29 8-29 26 0 37 105 34 105 110 0 37-21 67-62 75z"/></svg>');
-        background-repeat: no-repeat;
-        background-size: 4.125rem 3.625rem;
+    }
+
+    .logo .nimiq-logo {
+        height: 4rem;
+        width: 4rem;
+        margin-right: 2rem;
     }
 
     #app {
@@ -150,77 +142,18 @@ export default class App extends Vue {
     }
 
     .global-close {
-        display: inline-block;
-        height: 3.5rem;
-        border-radius: 1.75rem;
-        background-color: rgba(0, 0, 0, 0.1);
-        font-size: 1.75rem;
-        font-weight: 600;
-        line-height: 3.375rem;
-        color: white;
-        padding: 0 1.5rem;
-        cursor: pointer;
         margin-top: 8rem;
         margin-bottom: 5rem;
     }
 
-    .global-close::before {
-        content: '';
-        display: inline-block;
-        height: 1.375rem;
-        width: 1.375rem;
-        background-image: url('data:image/svg+xml,<svg height="24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h24v24H0z" fill="none"/><path fill="%23fff" d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/></svg>');
-        background-repeat: no-repeat;
-        background-size: 2rem;
-        background-position: center;
-        margin-right: 1rem;
-        margin-bottom: -0.125rem;
+    .global-close .arrow-left {
+        height: 2rem;
+        vertical-align: top;
+        margin-right: 0.25rem;
     }
 
     .global-close.hidden {
         visibility: hidden;
-        pointer-events: none;
-    }
-
-    /****************
-    ** Nimiq Style **
-    ****************/
-
-    /* buttons */
-
-    button::-moz-focus-inner {
-        border: 0;
-    }
-
-    button,
-    [button] {
-        font-size: 2rem;
-        font-weight: 600;
-        text-transform: uppercase;
-        letter-spacing: 0.094em;
-        width: 100%;
-        height: 8rem;
-        max-width: 41rem;
-        border-radius: 4rem;
-        padding: 0 4rem;
-        vertical-align: middle;
-        display: table-cell;
-        text-align: center;
-        background: white;
-        color: var(--main-button-color);
-        cursor: pointer;
-        user-select: none;
-        box-shadow: 0 1.25rem 1.75rem 0 rgba(0, 0, 0, 0.15);
-        border: none;
-        outline: none;
-        line-height: 1.25;
-        font-family: inherit;
-        box-sizing: border-box;
-    }
-
-    button[disabled],
-    [button][disabled] {
-        opacity: 0.6;
         pointer-events: none;
     }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -76,7 +76,6 @@ export default class App extends Vue {
     .logo {
         height: 3.625rem;
         box-sizing: border-box;
-        /* padding-left: 6rem; */
         font-size: 2.125rem;
         font-weight: 600;
         text-transform: uppercase;

--- a/src/App.vue
+++ b/src/App.vue
@@ -69,7 +69,7 @@ export default class App extends Vue {
 
     .logo-container {
         width: 100%;
-        padding: 4rem;
+        padding: 4rem 3rem;
         box-sizing: border-box;
     }
 
@@ -126,7 +126,6 @@ export default class App extends Vue {
     .loading-animation + h2 {
         margin-top: 4rem;
         padding-bottom: 8rem;
-        color: white;
         text-transform: uppercase;
         font-size: 1.75rem;
         font-weight: 600;
@@ -139,6 +138,11 @@ export default class App extends Vue {
         flex-direction: column;
         align-items: center;
         width: 100%;
+        flex-shrink: 0;
+    }
+
+    .container.pad-bottom {
+        margin-bottom: 12.5rem; /* Same height as the header (~100px) */
     }
 
     .global-close {

--- a/src/App.vue
+++ b/src/App.vue
@@ -147,7 +147,6 @@ export default class App extends Vue {
     }
 
     .global-close .arrow-left {
-        height: 2rem;
         vertical-align: top;
         margin-right: 0.25rem;
     }

--- a/src/components/CheckoutDetails.vue
+++ b/src/components/CheckoutDetails.vue
@@ -1,12 +1,14 @@
 <template>
     <div class="checkout-details">
-        <h1>You're sending <Amount :amount="request.value + request.fee"/> to</h1>
-        <Account :address="request.recipient.toUserFriendlyAddress()" :label="originDomain"/>
-        <div v-if="plainData" class="data">{{ plainData }}</div>
+        <div class="transaction-section">
+            <h1>You're sending <Amount :amount="request.value + request.fee"/> to</h1>
+            <Account :address="request.recipient.toUserFriendlyAddress()" :label="originDomain"/>
+            <p v-if="plainData" class="nq-text data">{{ plainData }}</p>
+        </div>
         <div class="sender-section">
             <div class="sender-nav">
-                <h2>Pay with</h2>
-                <button v-if="accountChangeable" @click="changeAccount">Change</button>
+                <span class="nq-label">Pay with</span>
+                <button class="nq-button-s" v-if="accountChangeable" @click="changeAccount">Change</button>
             </div>
             <Account v-if="activeAccount" :address="activeAccount.userFriendlyAddress" :label="activeAccount.label" :balance="activeAccount.balance"/>
         </div>
@@ -62,27 +64,30 @@ export default class CheckoutDetails extends Vue {
     h1 {
         font-size: 3rem;
         line-height: 3.625rem;
-        font-weight: 300;
+        font-weight: normal;
         letter-spacing: 0.021em;
         margin: 4rem 4rem 1rem 4rem;
     }
 
     h1 .amount {
-        font-weight: 500;
+        font-weight: bold;
     }
 
     .data {
-        font-size: 2rem;
-        line-height: 1.3;
-        opacity: 0.7;
-        padding: 1rem 4rem;
+        margin: 1rem 4rem;
+    }
+
+    .transaction-section {
+        background: white;
+        padding-bottom: 3rem;
+        border-top-left-radius: 1rem;
+        border-top-right-radius: 1rem;
+        flex-grow: 1;
     }
 
     .sender-section {
-        margin-top: 3rem;
         padding-bottom: 2rem;
         border-top: solid 1px #f0f0f0;
-        border-bottom: solid 1px #f0f0f0;
         background: #fafafa;
     }
 
@@ -93,24 +98,7 @@ export default class CheckoutDetails extends Vue {
         justify-content: space-between;
     }
 
-    .sender-nav h2 {
+    .sender-nav .nq-label {
         margin: 1rem;
-        font-size: 1.75rem;
-        text-transform: uppercase;
-        line-height: 0.86;
-        letter-spacing: 0.143em;
-        font-weight: 400;
-    }
-
-    .sender-nav button {
-        background: #e5e5e5;
-        padding: 1rem 1.75rem;
-        width: unset;
-        font-size: 1.75rem;
-        line-height: 0.86;
-        box-shadow: unset;
-        text-transform: unset;
-        letter-spacing: normal;
-        height: auto;
     }
 </style>

--- a/src/components/CheckoutDetails.vue
+++ b/src/components/CheckoutDetails.vue
@@ -78,7 +78,8 @@ export default class CheckoutDetails extends Vue {
     }
 
     .transaction-section {
-        background: white;
+        background: var(--nimiq-card-header-bg);
+        border-bottom: 1px solid var(--nimiq-card-border-color);
         padding-bottom: 3rem;
         border-top-left-radius: 1rem;
         border-top-right-radius: 1rem;
@@ -87,8 +88,7 @@ export default class CheckoutDetails extends Vue {
 
     .sender-section {
         padding-bottom: 2rem;
-        border-top: solid 1px #f0f0f0;
-        background: #fafafa;
+        background: var(--nimiq-card-bg);
     }
 
     .sender-nav {

--- a/src/components/Network.vue
+++ b/src/components/Network.vue
@@ -1,7 +1,7 @@
 <template>
-    <div class="network loading" :class="alwaysVisible || (visible && !consensusEstablished) ? '' : 'hidden'">
+    <div class="network loading nq-bg-blue" :class="alwaysVisible || (visible && !consensusEstablished) ? '' : 'hidden'">
         <div class="loading-animation"></div>
-        <div class="loading-status">{{ status }}</div>
+        <div class="loading-status nq-text-s">{{ status }}</div>
     </div>
 </template>
 
@@ -185,8 +185,6 @@ export default class Network extends Vue {
     .network {
         width: 100%;
         height: 20rem;
-        background: #724ceb;
-        color: white;
         border-radius: 0.5rem;
         flex-shrink: 0;
         padding: 3rem;
@@ -205,6 +203,7 @@ export default class Network extends Vue {
 
     .loading-status {
         margin-top: 2rem;
+        opacity: 0.7;
     }
 
     .loading-animation {

--- a/src/components/Success.vue
+++ b/src/components/Success.vue
@@ -4,8 +4,7 @@
         <h1 v-html="parsedText" class="nq-h1"></h1>
         <div style="flex-grow: 1;"></div>
 
-        <button v-if="buttonText" @click="$emit('continue')" class="nq-button green inverse" :disabled="disabled">{{ buttonText }}</button>
-        <button v-else @click="$emit('continue')" class="nq-button green inverse" :disabled="disabled">Back to {{ appName }}</button>
+        <button @click="$emit('continue')" class="nq-button green inverse" :disabled="disabled">{{ getButtonText }}</button>
     </div>
 </template>
 
@@ -25,6 +24,12 @@ export default class Success extends Vue {
         return this.text
             .replace(/<(.|\n)*?>/g, '')
             .replace(/\[br\]/g, '<br/>');
+    }
+
+    private get getButtonText(): string {
+        if (this.buttonText) return this.buttonText;
+        if (this.appName) return 'Back to ' + this.appName;
+        return 'Continue';
     }
 }
 </script>

--- a/src/components/Success.vue
+++ b/src/components/Success.vue
@@ -1,23 +1,30 @@
 <template>
-    <div class="success center">
-        <div class="icon-checkmark-circle"></div>
-        <h1 v-html="parsedText"></h1>
+    <div class="success nq-bg-green">
+        <div class="nq-icon checkmark-circle"></div>
+        <h1 v-html="parsedText" class="nq-h1"></h1>
         <div style="flex-grow: 1;"></div>
-        <button @click="$emit('continue')">Back to {{ appName }}</button>
+
+        <button v-if="buttonText" @click="$emit('continue')" class="nq-button green inverse" :disabled="disabled">{{ buttonText }}</button>
+        <button v-else @click="$emit('continue')" class="nq-button green inverse" :disabled="disabled">Back to {{ appName }}</button>
     </div>
 </template>
 
 <script lang="ts">
-import { Component, Vue, Prop, Emit } from 'vue-property-decorator';
+import { Component, Vue, Prop } from 'vue-property-decorator';
 
 @Component({})
 export default class Success extends Vue {
     @Prop(String) private text?: string;
     @Prop(String) private appName?: string;
+    @Prop(String) private buttonText?: string;
+    @Prop(Boolean) private disabled?: boolean;
 
-    get parsedText() {
+    private get parsedText(): string {
         if (!this.text) return '';
-        return this.text.replace(/<(.|\n)*?>/g, '').replace(/\[br\]/g, '<br/>');
+
+        return this.text
+            .replace(/<(.|\n)*?>/g, '')
+            .replace(/\[br\]/g, '<br/>');
     }
 }
 </script>
@@ -29,28 +36,26 @@ export default class Success extends Vue {
         justify-content: flex-start;
         align-items: center;
         flex-grow: 1;
-        margin: 8px;
-        background: #24bdb6;
-        color: white;
-        padding: 0 54px;
+        margin: 1rem;
+        border-radius: 0.5rem;
+        z-index: 1000;
     }
-    .icon-checkmark-circle {
-        width: 99px;
-        height: 99px;
-        margin-top: 96px;
-        background-image: url('data:image/svg+xml,<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve"><path d="M50,95C25.19,95,5,74.81,5,50S25.19,5,50,5s45,20.19,45,45S74.81,95,50,95z M50,0C22.43,0,0,22.43,0,50 s22.43,50,50,50s50-22.43,50-50S77.57,0,50,0z M81.41,29.11c-1.01-0.95-2.59-0.9-3.53,0.1L41.2,68.12L19.57,50.56 c-1.07-0.87-2.65-0.71-3.52,0.36c-0.87,1.07-0.71,2.65,0.36,3.52l23.44,19.02c0.46,0.38,1.02,0.56,1.58,0.56 c0.67,0,1.33-0.26,1.82-0.78l38.27-40.59C82.47,31.64,82.42,30.06,81.41,29.11z" fill="%23fff"/></svg>');
-        background-repeat: no-repeat;
-        background-size: 100%;
+
+    .checkmark-circle {
+        width: 12.5rem;
+        height: 12.5rem;
+        margin-top: 20%;
+        margin-bottom: 2rem;
     }
+
     h1 {
-        font-size: 30px;
-        font-weight: 300;
-        line-height: 1.3;
-        letter-spacing: 0.5px;
         text-align: center;
+        max-width: 50rem;
+        margin-left: auto;
+        margin-right: auto;
     }
+
     button {
-        color: #2a60dd;
-        margin: 24px 0;
+        margin: 3rem 0;
     }
 </style>

--- a/src/views/AddAccountSuccess.vue
+++ b/src/views/AddAccountSuccess.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="container">
+    <div class="container pad-bottom">
         <SmallPage>
             <PageHeader>Your account is ready</PageHeader>
             <PageBody>
@@ -89,10 +89,6 @@ export default class AddAccountSuccess extends Vue {
 </script>
 
 <style scoped>
-    .small-page {
-        margin-bottom: 15rem;
-    }
-
     .page-body {
         padding: 1rem 0 4rem 0;
     }

--- a/src/views/AddAccountSuccess.vue
+++ b/src/views/AddAccountSuccess.vue
@@ -1,29 +1,29 @@
 <template>
     <div class="container">
-        <small-page v-if="$route.name === `add-account-success`">
+        <SmallPage>
             <PageHeader>Your account is ready</PageHeader>
-            <div class="page-body">
-                <div class="success-box">
-                    <h2>Cool!</h2>
-                    <p>Your new account has been added to your wallet.</p>
+            <PageBody>
+                <div class="success-box nq-icon trumpet nq-bg-green">
+                    <h2 class="nq-h2">Awesome!</h2>
+                    <p class="nq-text">Your new account has been added to your wallet.</p>
                 </div>
 
                 <div class="login-label">
-                    <div class="login-icon" :class="walletIconClass"></div>
+                    <div class="login-icon nq-icon" :class="walletIconClass"></div>
                     {{ walletLabel }}
                 </div>
 
                 <Account :address="createdAddress.toUserFriendlyAddress()" :label="accountLabel" :editable="true" @changed="onAccountLabelChange"/>
 
-                <button class="submit" @click="done()">Open your account</button>
-            </div>
-        </small-page>
+                <button class="nq-button green submit" @click="done()">Open your account</button>
+            </PageBody>
+        </SmallPage>
     </div>
 </template>
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
-import { PageHeader, Account, LabelInput, SmallPage } from '@nimiq/vue-components';
+import { PageHeader, PageBody, Account, LabelInput, SmallPage } from '@nimiq/vue-components';
 import { AccountInfo } from '../lib/AccountInfo';
 import { WalletInfo, WalletType } from '../lib/WalletInfo';
 import { State, Getter } from 'vuex-class';
@@ -33,7 +33,7 @@ import { ResponseStatus, State as RpcState } from '@nimiq/rpc';
 import { AddAccountRequest, AddAccountResult } from '@/lib/RequestTypes';
 import { Static } from '../lib/StaticStore';
 
-@Component({components: {PageHeader, Account, LabelInput, SmallPage}})
+@Component({components: {PageHeader, PageBody, Account, LabelInput, SmallPage}})
 export default class AddAccountSuccess extends Vue {
     @Static private rpcState!: RpcState;
     @Static private request!: AddAccountRequest;
@@ -53,7 +53,6 @@ export default class AddAccountSuccess extends Vue {
     }
 
     private onAccountLabelChange(label: string) {
-        console.log(label);
         this.accountLabel = label;
         this.saveResult(this.accountLabel);
     }
@@ -90,38 +89,32 @@ export default class AddAccountSuccess extends Vue {
 </script>
 
 <style scoped>
-    .page-header {
-        border-bottom: none;
+    .small-page {
+        margin-bottom: 15rem;
+    }
+
+    .page-body {
+        padding: 1rem 0 4rem 0;
     }
 
     .success-box {
+        padding: 5rem 4rem;
         overflow: auto;
         margin: 0 1rem;
-        color: white;
         border-radius: 0.5rem;
-        background: #24bdb6;
         background-position: calc(100% - 2rem) center;
         background-size: auto 15.125rem;
-        background-repeat: no-repeat;
-        background-image: url('data:image/svg+xml,<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 169 169" style="enable-background:new 0 0 169 169;" xml:space="preserve" opacity="0.08"><path d="M50.73,59.45c-1.54,1.55-2.44,3.55-3.03,5.73l-0.07-0.04L1.36,152.08c-2.39,4.49-1.58,9.94,2.01,13.54 c2.22,2.22,5.13,3.38,8.09,3.38c1.84,0,3.7-0.44,5.41-1.37l86.58-46.31c2.26-0.6,4.24-1.62,5.78-3.17 c8.46-8.48,2.26-27.51-14.41-44.24C78.85,57.89,58.94,51.21,50.73,59.45 M104.26,113.16c-1.12,1.12-2.84,1.69-5.13,1.69 c-7.84,0-19.23-6.34-29.01-16.15C55.82,84.36,51.05,69.14,55.7,64.45c1.13-1.13,2.84-1.7,5.13-1.7c7.84,0,19.23,6.34,29.01,16.14 C104.14,93.26,108.92,108.48,104.26,113.16"/><path d="M167.98,83.01c-14.86-14.78-39.07-14.78-53.96,0c-1.36,1.35-1.36,3.56,0,4.91c0.68,0.68,1.58,1.02,2.47,1.02 c0.89,0,1.79-0.34,2.47-1.02c12.16-12.07,31.94-12.07,44.08,0c1.36,1.35,3.58,1.35,4.94,0S169.34,84.36,167.98,83.01"/><path d="M79.69,54.88c0.66,0.68,1.53,1.02,2.39,1.02c0.86,0,1.72-0.33,2.38-1.02c6.97-7.19,10.81-16.75,10.81-26.93 S91.43,8.22,84.46,1.02c-1.32-1.36-3.46-1.36-4.77,0c-1.32,1.37-1.32,3.57,0,4.93c5.69,5.88,8.83,13.69,8.83,22 c0,8.31-3.14,16.12-8.83,21.99C78.37,51.31,78.37,53.52,79.69,54.88"/><path d="M127.55,60.91c0.38,0,0.75-0.06,1.12-0.17l24.9-8.09c1.86-0.61,2.86-2.57,2.24-4.38 c-0.62-1.82-2.63-2.79-4.48-2.19l-24.9,8.09c-1.86,0.61-2.87,2.57-2.25,4.38C124.69,60,126.06,60.91,127.55,60.91"/><path d="M109.36,45.72c0.37,0.13,0.73,0.18,1.09,0.18c1.44,0,2.79-0.94,3.28-2.42l8.09-24.93 c0.6-1.86-0.38-3.87-2.19-4.49c-1.79-0.62-3.76,0.39-4.37,2.24l-8.09,24.93C106.58,43.09,107.55,45.1,109.36,45.72"/><path d="M109,64.92c1.88,0,3.64-0.73,4.95-2.06c2.73-2.74,2.73-7.19,0-9.96c-2.66-2.65-7.24-2.66-9.91,0.01 c-2.73,2.76-2.72,7.21,0.01,9.94C105.36,64.19,107.12,64.92,109,64.92"/><path d="M58,44.9c1.88,0,3.64-0.74,4.95-2.07c1.32-1.32,2.05-3.09,2.05-4.98c0-1.88-0.73-3.65-2.05-4.97 c-2.64-2.66-7.26-2.66-9.9-0.01C51.73,34.2,51,35.98,51,37.86c0,1.89,0.73,3.65,2.04,4.96C54.36,44.16,56.12,44.9,58,44.9"/><path d="M140,35.89c1.87,0,3.63-0.73,4.96-2.06c2.72-2.75,2.72-7.21-0.01-9.95c-2.64-2.66-7.26-2.66-9.9,0 c-2.73,2.75-2.73,7.2,0.01,9.96C136.37,35.16,138.13,35.89,140,35.89"/><path d="M131.05,93.93c-2.73,2.75-2.73,7.21,0,9.95c1.32,1.33,3.08,2.06,4.95,2.06s3.63-0.73,4.95-2.06 c2.73-2.75,2.73-7.21,0-9.96C138.3,91.27,133.7,91.27,131.05,93.93"/></svg>');
-    }
-
-    .success-box h2 {
-        margin: 3rem;
-        margin-bottom: 2rem;
-        font-size: 3rem;
-        letter-spacing: 0.021em;
-        font-weight: 500;
+        display: block;
+        width: unset;
+        height: unset;
     }
 
     .success-box p {
-        margin: 2rem 3rem;
         width: 25rem;
     }
 
     .success-box p + p {
         width: 20rem;
-        margin-bottom: 3rem;
     }
 
     .login-label {
@@ -142,24 +135,5 @@ export default class AddAccountSuccess extends Vue {
         width: 3rem;
         flex-shrink: 0;
         margin-right: 1rem;
-        background-repeat: no-repeat;
-        background-position: center;
-    }
-
-    .login-icon.keyguard {
-        background-image: url('data:image/svg+xml,<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 24 28" style="enable-background:new 0 0 24 28;" xml:space="preserve"><path fill="%23F5AF2D" d="M15.45,9.57c-0.15-0.3-0.57-0.53-0.89-0.53H9.42c-0.32,0-0.72,0.23-0.89,0.53l-2.57,4.49 c-0.15,0.28-0.15,0.76,0,1.03l2.57,4.49c0.17,0.3,0.57,0.53,0.89,0.53h5.14c0.35,0,0.74-0.23,0.89-0.53l2.57-4.49 c0.17-0.28,0.17-0.76,0-1.03L15.45,9.57z M23.58,5.29C23.83,5.36,24,5.59,24,5.85c0,10-0.87,17.98-11.8,22.11 C12.13,27.99,12.07,28,12,28c-0.07,0-0.13-0.01-0.2-0.04C0.87,23.83,0,15.85,0,5.85c0-0.26,0.17-0.49,0.42-0.56 c0.08-0.02,8.46-2.35,11.16-5.12c0.21-0.22,0.61-0.22,0.83,0C15.12,2.94,23.49,5.27,23.58,5.29z"/></svg>');
-        background-size: auto 3rem;
-    }
-
-    .login-icon.ledger {
-        background-image: url('data:image/svg+xml,<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 25 25" style="enable-background:new 0 0 25 25;" xml:space="preserve"><path fill="%23333745" d="M21.05,0H9.5V15.1H25l0-11.17C25,1.81,23.22,0,21.05,0"/><path fill="%23333745" d="M6.04,0H4.08C1.88,0,0,1.75,0,3.98v1.91h6.04V0z"/><rect fill="%23333745" y="9.21" width="6.08" height="5.92"/><path fill="%23333745" d="M18.92,25h1.97C23.11,25,25,23.24,25,21v-1.92h-6.08V25z"/><rect fill="%23333745" x="9.46" y="19.08" width="6.08" height="5.92"/><path fill="%23333745" d="M0,19.08V21c0,2.16,1.8,4,4.11,4h1.97v-5.92H0z"/></svg>');
-        background-size: 2.5rem;
-    }
-
-    button.submit {
-        margin: 2rem 8rem 4rem;
-        width: calc(100% - 15.5rem);
-        background: #24bdb6;
-        color: white;
     }
 </style>

--- a/src/views/AddAccountSuccess.vue
+++ b/src/views/AddAccountSuccess.vue
@@ -124,7 +124,7 @@ export default class AddAccountSuccess extends Vue {
         font-weight: 500;
         margin: 2rem 3rem 0;
         padding: 2rem 1rem;
-        border-bottom: solid 1px rgba(0, 0, 0, 0.1);
+        border-bottom: solid 1px var(--nimiq-card-border-color);
     }
 
     .login-icon {

--- a/src/views/AddAccountSuccess.vue
+++ b/src/views/AddAccountSuccess.vue
@@ -111,6 +111,7 @@ export default class AddAccountSuccess extends Vue {
 
     .success-box p {
         width: 25rem;
+        opacity: 1;
     }
 
     .success-box p + p {

--- a/src/views/Checkout.vue
+++ b/src/views/Checkout.vue
@@ -8,7 +8,7 @@
         <SmallPage>
             <router-view/>
         </SmallPage>
-        <button class="global-close nq-button-s" :class="{hidden: $route.name === `checkout-success`}" @click="close">
+        <button class="global-close nq-button-s" :class="{'hidden': $route.name === 'checkout-success'}" @click="close">
             <span class="nq-icon arrow-left"></span>
             Cancel Payment
         </button>

--- a/src/views/Checkout.vue
+++ b/src/views/Checkout.vue
@@ -1,14 +1,17 @@
 <template>
     <div class="container">
-        <PaymentInfoLine v-if="rpcState" style="color: white"
+        <PaymentInfoLine v-if="rpcState"
                          :amount="request.value"
                          :networkFee="request.fee"
                          :networkFeeEditable="false"
                          :origin="rpcState.origin"/>
-        <small-page>
+        <SmallPage>
             <router-view/>
-        </small-page>
-        <a class="global-close" :class="{hidden: $route.name === `checkout-success`}" @click="close">Cancel Payment</a>
+        </SmallPage>
+        <button class="global-close nq-button-s" :class="{hidden: $route.name === `checkout-success`}" @click="close">
+            <span class="nq-icon arrow-left"></span>
+            Cancel Payment
+        </button>
     </div>
 </template>
 

--- a/src/views/CheckoutOverview.vue
+++ b/src/views/CheckoutOverview.vue
@@ -1,17 +1,17 @@
 <template>
     <div class="checkout-overview">
         <CheckoutDetails :accountChangeable="true"/>
-        <div class="page-footer" :class="height === 0 ? 'shows-network' : ''">
+        <PageFooter :class="height === 0 ? 'shows-network' : ''">
             <Network ref="network" :visible="height === 0" message="Fetching network status" @head-change="_onHeadChange"/>
-            <button v-if="height > 0" @click="proceed">Pay <Amount :amount="request.value + request.fee"/></button>
-        </div>
+            <button class="nq-button" v-if="height > 0" @click="proceed">Pay <Amount :amount="request.value + request.fee"/></button>
+        </PageFooter>
     </div>
 </template>
 
 <script lang="ts">
 import { Component, Emit, Watch, Vue } from 'vue-property-decorator';
 import { Getter } from 'vuex-class';
-import { Amount } from '@nimiq/vue-components';
+import { Amount, PageFooter } from '@nimiq/vue-components';
 import { SignTransactionRequest as KSignTransactionRequest } from '@nimiq/keyguard-client';
 import { State as RpcState } from '@nimiq/rpc';
 import CheckoutDetails from '../components/CheckoutDetails.vue';
@@ -22,7 +22,7 @@ import RpcApi from '../lib/RpcApi';
 import staticStore, { Static } from '../lib/StaticStore';
 import Network from '../components/Network.vue';
 
-@Component({components: {Amount, CheckoutDetails, Network}})
+@Component({components: {Amount, PageFooter, CheckoutDetails, Network}})
 export default class CheckoutOverview extends Vue {
     @Static private rpcState!: RpcState;
     @Static private request!: ParsedCheckoutRequest;
@@ -120,21 +120,11 @@ export default class CheckoutOverview extends Vue {
         flex-grow: 1;
     }
 
-    .page-footer {
-        display: flex;
-        flex-direction: column;
-        justify-content: flex-end;
-        align-items: center;
-        padding: 4rem 8rem;
-        flex-grow: 1;
-    }
-
     .page-footer.shows-network {
         padding: 1rem;
     }
 
-    .page-footer button {
-        background: #724ceb;
-        color: white;
+    .page-footer .nq-button {
+        margin: 0 auto;
     }
 </style>

--- a/src/views/CheckoutTransmission.vue
+++ b/src/views/CheckoutTransmission.vue
@@ -78,7 +78,7 @@ export default class CheckoutTransmission extends Vue {
         0% {
             background: var(--nimiq-blue);
             background-image: var(--nimiq-blue-bg);
-            max-height: 160px;
+            max-height: 20rem;
         }
 
         100% {

--- a/src/views/CheckoutTransmission.vue
+++ b/src/views/CheckoutTransmission.vue
@@ -1,7 +1,9 @@
 <template>
     <div class="checkout-transmission">
         <CheckoutDetails :accountChangeable="false"/>
-        <Network ref="network" :alwaysVisible="true" message="Sending transaction"/>
+        <PageFooter>
+            <Network ref="network" :alwaysVisible="true" message="Sending transaction"/>
+        </PageFooter>
         <transition name='fade-in'>
             <Success v-if="isTxSent"
                 text="Your payment[br]was successful"
@@ -25,8 +27,9 @@ import { State } from 'vuex-class';
 import { Static } from '../lib/StaticStore';
 import { AccountInfo } from '../lib/AccountInfo';
 import Success from '../components/Success.vue';
+import { PageFooter } from '@nimiq/vue-components';
 
-@Component({components: {Network, CheckoutDetails, Success}})
+@Component({components: {PageFooter, Network, CheckoutDetails, Success}})
 export default class CheckoutTransmission extends Vue {
     @Static private rpcState!: RpcState;
     @Static private keyguardRequest!: KSignTransactionRequest;
@@ -55,9 +58,8 @@ export default class CheckoutTransmission extends Vue {
         position: relative;
     }
 
-    .network {
-        width: calc(100% - 2rem);
-        margin: 1rem;
+    .page-footer {
+        padding: 1rem;
     }
 
     .success {
@@ -65,55 +67,24 @@ export default class CheckoutTransmission extends Vue {
         bottom: 0;
         left: 0;
         height: calc(100% - 2rem);
-        display: flex;
-        flex-direction: column;
-        justify-content: flex-start;
-        align-items: center;
-        align-self: flex-end;
-        flex-grow: 1;
-        margin: 1rem;
-        color: white;
-        padding: 0 6.75rem;
-        background: #24bdb6;
-        overflow: hidden;
-        z-index: 1000;
-    }
-
-    .icon-checkmark-circle {
-        width: 12.375rem;
-        height: 12.375rem;
-        margin-top: 12rem;
-        background-image: url('data:image/svg+xml,<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve"><path d="M50,95C25.19,95,5,74.81,5,50S25.19,5,50,5s45,20.19,45,45S74.81,95,50,95z M50,0C22.43,0,0,22.43,0,50 s22.43,50,50,50s50-22.43,50-50S77.57,0,50,0z M81.41,29.11c-1.01-0.95-2.59-0.9-3.53,0.1L41.2,68.12L19.57,50.56 c-1.07-0.87-2.65-0.71-3.52,0.36c-0.87,1.07-0.71,2.65,0.36,3.52l23.44,19.02c0.46,0.38,1.02,0.56,1.58,0.56 c0.67,0,1.33-0.26,1.82-0.78l38.27-40.59C82.47,31.64,82.42,30.06,81.41,29.11z" fill="%23fff"/></svg>');
-        background-repeat: no-repeat;
-        background-size: 100%;
+        width: calc(100% - 2rem);
     }
 
     .fade-in-enter-active {
-        animation: enter 1s;
+        animation: color-shift 1s;
     }
 
-    @keyframes enter {
+    @keyframes color-shift {
         0% {
-            background: #6843df;
+            background: var(--nimiq-blue);
+            background-image: var(--nimiq-blue-bg);
             max-height: 160px;
         }
 
         100% {
-            background: #24bdb6;
+            background: var(--nimiq-green);
+            background-image: var(--nimiq-green-bg);
             max-height: 100%;
         }
-    }
-
-    .success h1 {
-        font-size: 3.75rem;
-        font-weight: 300;
-        line-height: 1.3;
-        letter-spacing: 0.017em;
-        text-align: center;
-    }
-
-    .success button {
-        color: #2a60dd;
-        margin: 3rem 0;
     }
 </style>

--- a/src/views/LoginSuccess.vue
+++ b/src/views/LoginSuccess.vue
@@ -1,22 +1,24 @@
 <template>
     <div class="container">
-        <small-page>
+        <SmallPage>
             <div class="login-success">
                 <PageHeader>Your wallet is ready</PageHeader>
 
-        <PageBody>
-            <div class="wallet-label" v-if="keyguardResult.keyType !== 0 /* LEGACY */">
-                <div class="wallet-icon nq-icon" :class="walletIconClass"></div>
-                <LabelInput :value="walletLabel" @changed="onWalletLabelChange"/>
+                <PageBody>
+                    <div class="wallet-label" v-if="keyguardResult.keyType !== 0 /* LEGACY */">
+                        <div class="wallet-icon nq-icon" :class="walletIconClass"></div>
+                        <LabelInput :value="walletLabel" @changed="onWalletLabelChange"/>
+                    </div>
+
+                    <AccountList :accounts="accountsArray" :editable="true" @account-changed="onAccountLabelChanged"/>
+                </PageBody>
+
+                <PageFooter>
+                    <Network :visible="keyguardResult.keyType !== 0 /* LEGACY */" :message="'Detecting your accounts'" ref="network"/>
+                    <button class="nq-button" @click="done">Back to {{ request.appName }}</button>
+                </PageFooter>
             </div>
-
-            <AccountList :accounts="accountsArray" :editable="true" @account-changed="onAccountLabelChanged"/>
-        </PageBody>
-
-        <PageFooter>
-            <Network :visible="keyguardResult.keyType !== 0 /* LEGACY */" :message="'Detecting your accounts'" ref="network"/>
-            <button class="nq-button" @click="done">Back to {{ request.appName }}</button>
-        </PageFooter>
+        </SmallPage>
     </div>
 </template>
 

--- a/src/views/LoginSuccess.vue
+++ b/src/views/LoginSuccess.vue
@@ -4,21 +4,19 @@
             <div class="login-success">
                 <PageHeader>Your wallet is ready</PageHeader>
 
-        <div class="page-body">
+        <PageBody>
             <div class="wallet-label" v-if="keyguardResult.keyType !== 0 /* LEGACY */">
-                <div class="wallet-icon" :class="walletIconClass"></div>
+                <div class="wallet-icon nq-icon" :class="walletIconClass"></div>
                 <LabelInput :value="walletLabel" @changed="onWalletLabelChange"/>
             </div>
 
             <AccountList :accounts="accountsArray" :editable="true" @account-changed="onAccountLabelChanged"/>
-        </div>
+        </PageBody>
 
-                <PageFooter>
-                    <Network :visible="keyguardResult.keyType !== 0 /* LEGACY */" :message="'Detecting your accounts'" ref="network"/>
-                    <button @click="done">Back to {{ request.appName }}</button>
-                </PageFooter>
-            </div>
-        </small-page>
+        <PageFooter>
+            <Network :visible="keyguardResult.keyType !== 0 /* LEGACY */" :message="'Detecting your accounts'" ref="network"/>
+            <button class="nq-button" @click="done">Back to {{ request.appName }}</button>
+        </PageFooter>
     </div>
 </template>
 
@@ -32,10 +30,10 @@ import { ResponseStatus, State as RpcState } from '@nimiq/rpc';
 import { AccountInfo } from '@/lib/AccountInfo';
 import { WalletStore } from '@/lib/WalletStore';
 import { Static } from '@/lib/StaticStore';
-import { PageHeader, LabelInput, AccountList, PageFooter, SmallPage } from '@nimiq/vue-components';
+import { PageHeader, PageBody, LabelInput, AccountList, PageFooter, SmallPage } from '@nimiq/vue-components';
 import Network from '@/components/Network.vue';
 
-@Component({components: {PageHeader, LabelInput, AccountList, Network, PageFooter, SmallPage}})
+@Component({components: {PageHeader, PageBody, LabelInput, AccountList, Network, PageFooter, SmallPage}})
 export default class LoginSuccess extends Vue {
     @Static private request!: ParsedLoginRequest;
     @Static private rpcState!: RpcState;
@@ -239,8 +237,7 @@ export default class LoginSuccess extends Vue {
     }
 
     .page-body {
-        background: #fafafa;
-        flex-grow: 1;
+        padding: 2rem 0;
     }
 
     .wallet-label {
@@ -261,29 +258,9 @@ export default class LoginSuccess extends Vue {
         width: 3rem;
         flex-shrink: 0;
         margin-right: 1rem;
-        background-repeat: no-repeat;
-        background-position: center;
     }
 
-    .wallet-icon.keyguard {
-        background-image: url('data:image/svg+xml,<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 24 28" style="enable-background:new 0 0 24 28;" xml:space="preserve"><path fill="%23F5AF2D" d="M15.45,9.57c-0.15-0.3-0.57-0.53-0.89-0.53H9.42c-0.32,0-0.72,0.23-0.89,0.53l-2.57,4.49 c-0.15,0.28-0.15,0.76,0,1.03l2.57,4.49c0.17,0.3,0.57,0.53,0.89,0.53h5.14c0.35,0,0.74-0.23,0.89-0.53l2.57-4.49 c0.17-0.28,0.17-0.76,0-1.03L15.45,9.57z M23.58,5.29C23.83,5.36,24,5.59,24,5.85c0,10-0.87,17.98-11.8,22.11 C12.13,27.99,12.07,28,12,28c-0.07,0-0.13-0.01-0.2-0.04C0.87,23.83,0,15.85,0,5.85c0-0.26,0.17-0.49,0.42-0.56 c0.08-0.02,8.46-2.35,11.16-5.12c0.21-0.22,0.61-0.22,0.83,0C15.12,2.94,23.49,5.27,23.58,5.29z"/></svg>');
-        background-size: auto 3rem;
-    }
-
-    .wallet-icon.ledger {
-        background-image: url('data:image/svg+xml,<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 25 25" style="enable-background:new 0 0 25 25;" xml:space="preserve"><path fill="%23333745" d="M21.05,0H9.5V15.1H25l0-11.17C25,1.81,23.22,0,21.05,0"/><path fill="%23333745" d="M6.04,0H4.08C1.88,0,0,1.75,0,3.98v1.91h6.04V0z"/><rect fill="%23333745" y="9.21" width="6.08" height="5.92"/><path fill="%23333745" d="M18.92,25h1.97C23.11,25,25,23.24,25,21v-1.92h-6.08V25z"/><rect fill="%23333745" x="9.46" y="19.08" width="6.08" height="5.92"/><path fill="%23333745" d="M0,19.08V21c0,2.16,1.8,4,4.11,4h1.97v-5.92H0z"/></svg>');
-        background-size: 2.5rem;
-    }
-
-    button {
-        background: #724ceb;
-        color: white;
-        margin: 3rem 0;
-    }
-
-    .page-footer {
-        height: auto;
-        padding: 1rem;
-        flex-direction: column;
+    .page-footer .nq-button {
+        margin: 0 auto;
     }
 </style>

--- a/src/views/LoginSuccess.vue
+++ b/src/views/LoginSuccess.vue
@@ -252,7 +252,7 @@ export default class LoginSuccess extends Vue {
         font-weight: 500;
         margin: 2rem 3rem 0;
         padding: 2rem 1rem;
-        border-bottom: solid 1px rgba(0, 0, 0, 0.1);
+        border-bottom: solid 1px var(--nimiq-card-border-color);
     }
 
     .wallet-icon {

--- a/src/views/LoginSuccess.vue
+++ b/src/views/LoginSuccess.vue
@@ -239,7 +239,7 @@ export default class LoginSuccess extends Vue {
     }
 
     .page-body {
-        padding: 2rem 0;
+        padding: 0;
     }
 
     .wallet-label {
@@ -250,8 +250,8 @@ export default class LoginSuccess extends Vue {
         font-size: 2.25rem;
         line-height: 2.5rem;
         font-weight: 500;
-        margin: 2rem 3rem 0;
-        padding: 2rem 1rem;
+        margin: 0 3rem;
+        padding: 2rem 1rem 1.5rem;
         border-bottom: solid 1px var(--nimiq-card-border-color);
     }
 

--- a/src/views/SignTransactionSuccess.vue
+++ b/src/views/SignTransactionSuccess.vue
@@ -1,14 +1,14 @@
 <template>
     <div class="container">
-        <small-page>
-            <div class="success center">
-                <div class="icon-checkmark-circle"></div>
-                <h1>Your transaction<br>is ready!</h1>
-                <div style="flex-grow: 1;"></div>
-                <button @click="done" :disabled="!isTxPrepared">Send now</button>
-                <Network ref="network"/>
-            </div>
-        </small-page>
+        <SmallPage>
+            <Success
+                text="Your transaction[br]is ready!"
+                buttonText="Send now"
+                :disabled="!isTxPrepared"
+                @continue="done"
+            />
+            <Network ref="network"/>
+        </SmallPage>
     </div>
 </template>
 
@@ -24,8 +24,9 @@ import {
 } from '@nimiq/keyguard-client';
 import { State } from 'vuex-class';
 import { Static } from '../lib/StaticStore';
+import Success from '../components/Success.vue';
 
-@Component({components: {Network, SmallPage}})
+@Component({components: {Network, SmallPage, Success}})
 export default class SignTransactionSuccess extends Vue {
     @Static private request!: ParsedSignTransactionRequest;
     @Static private rpcState!: RpcState;
@@ -46,39 +47,3 @@ export default class SignTransactionSuccess extends Vue {
     }
 }
 </script>
-
-<style scoped>
-    .success {
-        display: flex;
-        flex-direction: column;
-        justify-content: flex-start;
-        align-items: center;
-        flex-grow: 1;
-        margin: 1rem;
-        background: #24bdb6;
-        color: white;
-        padding: 0 6.75rem;
-    }
-
-    .icon-checkmark-circle {
-        width: 12.375rem;
-        height: 12.375rem;
-        margin-top: 12rem;
-        background-image: url('data:image/svg+xml,<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve"><path d="M50,95C25.19,95,5,74.81,5,50S25.19,5,50,5s45,20.19,45,45S74.81,95,50,95z M50,0C22.43,0,0,22.43,0,50 s22.43,50,50,50s50-22.43,50-50S77.57,0,50,0z M81.41,29.11c-1.01-0.95-2.59-0.9-3.53,0.1L41.2,68.12L19.57,50.56 c-1.07-0.87-2.65-0.71-3.52,0.36c-0.87,1.07-0.71,2.65,0.36,3.52l23.44,19.02c0.46,0.38,1.02,0.56,1.58,0.56 c0.67,0,1.33-0.26,1.82-0.78l38.27-40.59C82.47,31.64,82.42,30.06,81.41,29.11z" fill="%23fff"/></svg>');
-        background-repeat: no-repeat;
-        background-size: 100%;
-    }
-
-    h1 {
-        font-size: 3.75rem;
-        font-weight: 300;
-        line-height: 1.3;
-        letter-spacing: 0.017em;
-        text-align: center;
-    }
-
-    button {
-        color: #2a60dd;
-        margin: 3rem 0;
-    }
-</style>

--- a/src/views/SignupSuccess.vue
+++ b/src/views/SignupSuccess.vue
@@ -1,24 +1,24 @@
 <template>
     <div class="container">
         <small-page>
-            <div>
-                <PageHeader :progressIndicator="true" :numberSteps="6" :step="6">Your wallet is ready</PageHeader>
-                <div class="page-body">
-                    <div class="success-box">
-                        <h2>Awesome!</h2>
-                        <p>Your Keyguard Wallet is set up. It already contains your newly created account.</p>
-                        <p>You can add more accounts to it later.</p>
-                    </div>
+    <div>
+        <PageHeader :progressIndicator="true" :numberSteps="6" :step="6">Your wallet is ready</PageHeader>
+        <PageBody>
+            <div class="success-box nq-icon trumpet nq-bg-green">
+                <h2 class="nq-h2">Awesome!</h2>
+                <p class="nq-text">Your Keyguard Wallet is set up. It already contains your newly created account.</p>
+                <p class="nq-text">You can add more accounts to it later.</p>
+            </div>
 
-                    <div class="wallet-label">
-                        <div class="wallet-icon" :class="walletIconClass"></div>
-                        <LabelInput :value="walletLabel" @changed="onWalletLabelChange"/>
-                    </div>
+            <div class="wallet-label">
+                <div class="wallet-icon nq-icon" :class="walletIconClass"></div>
+                <LabelInput :value="walletLabel" @changed="onWalletLabelChange"/>
+            </div>
 
                     <Account :address="createdAddress.toUserFriendlyAddress()" :label="accountLabel" :editable="true" @changed="onAccountLabelChange"/>
 
-                    <button class="submit" @click="done()">Open your wallet</button>
-                </div>
+            <button class="nq-button green submit" @click="done()">Open your wallet</button>
+        </PageBody>
             </div>
         </small-page>
     </div>
@@ -27,7 +27,7 @@
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
-import { PageHeader, Account, LabelInput, SmallPage } from '@nimiq/vue-components';
+import { PageHeader, PageBody, Account, LabelInput, SmallPage } from '@nimiq/vue-components';
 import { AccountInfo } from '../lib/AccountInfo';
 import { WalletInfo, WalletType } from '../lib/WalletInfo';
 import { State, Getter } from 'vuex-class';
@@ -37,7 +37,7 @@ import { ResponseStatus, State as RpcState } from '@nimiq/rpc';
 import { SignupResult } from '@/lib/RequestTypes';
 import { Static } from '../lib/StaticStore';
 
-@Component({components: {PageHeader, Account, LabelInput, SmallPage}})
+@Component({components: {PageHeader, PageBody, Account, LabelInput, SmallPage}})
 export default class SignupSuccess extends Vue {
     @Static private rpcState!: RpcState;
     @State private keyguardResult!: CreateResult;
@@ -104,38 +104,29 @@ export default class SignupSuccess extends Vue {
 </script>
 
 <style scoped>
-    .page-header {
-        border-bottom: none;
+    .page-body {
+        padding: 1rem 0 4rem;
     }
 
     .success-box {
+        padding: 3rem 4rem;
         overflow: auto;
         margin: 0 1rem;
-        color: white;
         border-radius: 0.5rem;
-        background: #24bdb6;
         background-position: calc(100% - 2rem) center;
         background-size: auto 21.125rem;
-        background-repeat: no-repeat;
-        background-image: url('data:image/svg+xml,<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 169 169" style="enable-background:new 0 0 169 169;" xml:space="preserve" opacity="0.08"><path d="M50.73,59.45c-1.54,1.55-2.44,3.55-3.03,5.73l-0.07-0.04L1.36,152.08c-2.39,4.49-1.58,9.94,2.01,13.54 c2.22,2.22,5.13,3.38,8.09,3.38c1.84,0,3.7-0.44,5.41-1.37l86.58-46.31c2.26-0.6,4.24-1.62,5.78-3.17 c8.46-8.48,2.26-27.51-14.41-44.24C78.85,57.89,58.94,51.21,50.73,59.45 M104.26,113.16c-1.12,1.12-2.84,1.69-5.13,1.69 c-7.84,0-19.23-6.34-29.01-16.15C55.82,84.36,51.05,69.14,55.7,64.45c1.13-1.13,2.84-1.7,5.13-1.7c7.84,0,19.23,6.34,29.01,16.14 C104.14,93.26,108.92,108.48,104.26,113.16"/><path d="M167.98,83.01c-14.86-14.78-39.07-14.78-53.96,0c-1.36,1.35-1.36,3.56,0,4.91c0.68,0.68,1.58,1.02,2.47,1.02 c0.89,0,1.79-0.34,2.47-1.02c12.16-12.07,31.94-12.07,44.08,0c1.36,1.35,3.58,1.35,4.94,0S169.34,84.36,167.98,83.01"/><path d="M79.69,54.88c0.66,0.68,1.53,1.02,2.39,1.02c0.86,0,1.72-0.33,2.38-1.02c6.97-7.19,10.81-16.75,10.81-26.93 S91.43,8.22,84.46,1.02c-1.32-1.36-3.46-1.36-4.77,0c-1.32,1.37-1.32,3.57,0,4.93c5.69,5.88,8.83,13.69,8.83,22 c0,8.31-3.14,16.12-8.83,21.99C78.37,51.31,78.37,53.52,79.69,54.88"/><path d="M127.55,60.91c0.38,0,0.75-0.06,1.12-0.17l24.9-8.09c1.86-0.61,2.86-2.57,2.24-4.38 c-0.62-1.82-2.63-2.79-4.48-2.19l-24.9,8.09c-1.86,0.61-2.87,2.57-2.25,4.38C124.69,60,126.06,60.91,127.55,60.91"/><path d="M109.36,45.72c0.37,0.13,0.73,0.18,1.09,0.18c1.44,0,2.79-0.94,3.28-2.42l8.09-24.93 c0.6-1.86-0.38-3.87-2.19-4.49c-1.79-0.62-3.76,0.39-4.37,2.24l-8.09,24.93C106.58,43.09,107.55,45.1,109.36,45.72"/><path d="M109,64.92c1.88,0,3.64-0.73,4.95-2.06c2.73-2.74,2.73-7.19,0-9.96c-2.66-2.65-7.24-2.66-9.91,0.01 c-2.73,2.76-2.72,7.21,0.01,9.94C105.36,64.19,107.12,64.92,109,64.92"/><path d="M58,44.9c1.88,0,3.64-0.74,4.95-2.07c1.32-1.32,2.05-3.09,2.05-4.98c0-1.88-0.73-3.65-2.05-4.97 c-2.64-2.66-7.26-2.66-9.9-0.01C51.73,34.2,51,35.98,51,37.86c0,1.89,0.73,3.65,2.04,4.96C54.36,44.16,56.12,44.9,58,44.9"/><path d="M140,35.89c1.87,0,3.63-0.73,4.96-2.06c2.72-2.75,2.72-7.21-0.01-9.95c-2.64-2.66-7.26-2.66-9.9,0 c-2.73,2.75-2.73,7.2,0.01,9.96C136.37,35.16,138.13,35.89,140,35.89"/><path d="M131.05,93.93c-2.73,2.75-2.73,7.21,0,9.95c1.32,1.33,3.08,2.06,4.95,2.06s3.63-0.73,4.95-2.06 c2.73-2.75,2.73-7.21,0-9.96C138.3,91.27,133.7,91.27,131.05,93.93"/></svg>');
-    }
-
-    .success-box h2 {
-        margin: 3rem;
-        margin-bottom: 2rem;
-        font-size: 3rem;
-        letter-spacing: 0.021em;
-        font-weight: 500;
+        display: block;
+        width: unset;
+        height: unset;
     }
 
     .success-box p {
-        margin: 2rem 3rem;
-        width: 25rem;
+        width: 28rem;
+        opacity: 1;
     }
 
     .success-box p + p {
-        width: 20rem;
-        margin-bottom: 3rem;
+        width: 24rem;
     }
 
     .wallet-label {
@@ -156,24 +147,5 @@ export default class SignupSuccess extends Vue {
         width: 3rem;
         flex-shrink: 0;
         margin-right: 1rem;
-        background-repeat: no-repeat;
-        background-position: center;
-    }
-
-    .wallet-icon.keyguard {
-        background-image: url('data:image/svg+xml,<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 24 28" style="enable-background:new 0 0 24 28;" xml:space="preserve"><path fill="%23F5AF2D" d="M15.45,9.57c-0.15-0.3-0.57-0.53-0.89-0.53H9.42c-0.32,0-0.72,0.23-0.89,0.53l-2.57,4.49 c-0.15,0.28-0.15,0.76,0,1.03l2.57,4.49c0.17,0.3,0.57,0.53,0.89,0.53h5.14c0.35,0,0.74-0.23,0.89-0.53l2.57-4.49 c0.17-0.28,0.17-0.76,0-1.03L15.45,9.57z M23.58,5.29C23.83,5.36,24,5.59,24,5.85c0,10-0.87,17.98-11.8,22.11 C12.13,27.99,12.07,28,12,28c-0.07,0-0.13-0.01-0.2-0.04C0.87,23.83,0,15.85,0,5.85c0-0.26,0.17-0.49,0.42-0.56 c0.08-0.02,8.46-2.35,11.16-5.12c0.21-0.22,0.61-0.22,0.83,0C15.12,2.94,23.49,5.27,23.58,5.29z"/></svg>');
-        background-size: auto 3rem;
-    }
-
-    .wallet-icon.ledger {
-        background-image: url('data:image/svg+xml,<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 25 25" style="enable-background:new 0 0 25 25;" xml:space="preserve"><path fill="%23333745" d="M21.05,0H9.5V15.1H25l0-11.17C25,1.81,23.22,0,21.05,0"/><path fill="%23333745" d="M6.04,0H4.08C1.88,0,0,1.75,0,3.98v1.91h6.04V0z"/><rect fill="%23333745" y="9.21" width="6.08" height="5.92"/><path fill="%23333745" d="M18.92,25h1.97C23.11,25,25,23.24,25,21v-1.92h-6.08V25z"/><rect fill="%23333745" x="9.46" y="19.08" width="6.08" height="5.92"/><path fill="%23333745" d="M0,19.08V21c0,2.16,1.8,4,4.11,4h1.97v-5.92H0z"/></svg>');
-        background-size: 2.5rem;
-    }
-
-    button.submit {
-        margin: 2rem 8rem 4rem;
-        width: calc(100% - 15.5rem);
-        background: #24bdb6;
-        color: white;
     }
 </style>

--- a/src/views/SignupSuccess.vue
+++ b/src/views/SignupSuccess.vue
@@ -1,28 +1,25 @@
 <template>
     <div class="container">
-        <small-page>
-    <div>
-        <PageHeader :progressIndicator="true" :numberSteps="6" :step="6">Your wallet is ready</PageHeader>
-        <PageBody>
-            <div class="success-box nq-icon trumpet nq-bg-green">
-                <h2 class="nq-h2">Awesome!</h2>
-                <p class="nq-text">Your Keyguard Wallet is set up. It already contains your newly created account.</p>
-                <p class="nq-text">You can add more accounts to it later.</p>
-            </div>
+        <SmallPage>
+            <PageHeader :progressIndicator="true" :numberSteps="6" :step="6">Your wallet is ready</PageHeader>
+            <PageBody>
+                <div class="success-box nq-icon trumpet nq-bg-green">
+                    <h2 class="nq-h2">Awesome!</h2>
+                    <p class="nq-text">Your Keyguard Wallet is set up. It already contains your newly created account.</p>
+                    <p class="nq-text">You can add more accounts to it later.</p>
+                </div>
 
-            <div class="wallet-label">
-                <div class="wallet-icon nq-icon" :class="walletIconClass"></div>
-                <LabelInput :value="walletLabel" @changed="onWalletLabelChange"/>
-            </div>
+                <div class="wallet-label">
+                    <div class="wallet-icon nq-icon" :class="walletIconClass"></div>
+                    <LabelInput :value="walletLabel" @changed="onWalletLabelChange"/>
+                </div>
 
-                    <Account :address="createdAddress.toUserFriendlyAddress()" :label="accountLabel" :editable="true" @changed="onAccountLabelChange"/>
+                <Account :address="createdAddress.toUserFriendlyAddress()" :label="accountLabel" :editable="true" @changed="onAccountLabelChange"/>
 
-            <button class="nq-button green submit" @click="done()">Open your wallet</button>
-        </PageBody>
-            </div>
-        </small-page>
+                <button class="nq-button green submit" @click="done()">Open your wallet</button>
+            </PageBody>
+        </SmallPage>
     </div>
-
 </template>
 
 <script lang="ts">

--- a/src/views/SignupSuccess.vue
+++ b/src/views/SignupSuccess.vue
@@ -136,7 +136,7 @@ export default class SignupSuccess extends Vue {
         font-weight: 500;
         margin: 2rem 3rem 0;
         padding: 2rem 1rem;
-        border-bottom: solid 1px rgba(0, 0, 0, 0.1);
+        border-bottom: solid 1px var(--nimiq-card-border-color);
     }
 
     .wallet-icon {

--- a/src/views/SignupTypeSelector.vue
+++ b/src/views/SignupTypeSelector.vue
@@ -78,7 +78,7 @@ export default class SignupTypeSelector extends Vue {
     }
 
     .ledger-button {
-        border: solid 0.25rem #e5e5e5;
+        border: solid 0.25rem var(--nimiq-border-color);
         background: none;
         color: inherit;
     }

--- a/src/views/SignupTypeSelector.vue
+++ b/src/views/SignupTypeSelector.vue
@@ -1,25 +1,27 @@
 <template>
     <div class="container">
-        <small-page>
-    <div>
-        <PageHeader :progressIndicator="true" :numberSteps="6" :step="1">Add a Wallet</PageHeader>
-        <PageBody>
-            <p class="nq-text">A Wallet is like a login and can contain one or more accounts, which you can use to send or receive Nimiq, pay online and create Cashlinks.</p>
-            <button @click="createKeyguard" class="keyguard-button nq-bg-blue">
-                <h2 class="nq-h2">Create Wallet</h2>
-                <p class="nq-text">Create a Wallet in our secure Nimiq Keyguard. This is the most convenient option.</p>
-            </button>
-            <button @click="createLedger" class="ledger-button">
-                <h2 class="nq-h2">Connect Hardware Wallet</h2>
-                <p class="nq-text">Connect a Hardware Wallet like Ledger. This option requires a physical device. It is the most secure option.</p>
-            </button>
-        </PageBody>
-        <PageFooter>
-            <a class="nq-link" onclick="alert('Not yet implemented')" href="javascript:void(0);">Already have a wallet?</a>
-        </PageFooter>
-            </div>
-        </small-page>
-        <a class="global-close" @click="close">Back to {{request.appName}}</a>
+        <SmallPage>
+            <PageHeader :progressIndicator="true" :numberSteps="6" :step="1">Add a Wallet</PageHeader>
+            <PageBody>
+                <p class="nq-text">A Wallet is like a login and can contain one or more accounts, which you can use to send or receive Nimiq, pay online and create Cashlinks.</p>
+                <button @click="createKeyguard" class="keyguard-button nq-bg-blue">
+                    <h2 class="nq-h2">Create Wallet</h2>
+                    <p class="nq-text">Create a Wallet in our secure Nimiq Keyguard. This is the most convenient option.</p>
+                </button>
+                <button @click="createLedger" class="ledger-button">
+                    <h2 class="nq-h2">Connect Hardware Wallet</h2>
+                    <p class="nq-text">Connect a Hardware Wallet like Ledger. This option requires a physical device. It is the most secure option.</p>
+                </button>
+            </PageBody>
+            <PageFooter>
+                <a class="nq-link" onclick="alert('Not yet implemented')" href="javascript:void(0);">Already have a wallet?</a>
+            </PageFooter>
+        </SmallPage>
+
+        <button class="global-close nq-button-s" @click="close">
+            <span class="nq-icon arrow-left"></span>
+            Back to {{request.appName}}
+        </button>
     </div>
 </template>
 

--- a/src/views/SignupTypeSelector.vue
+++ b/src/views/SignupTypeSelector.vue
@@ -78,7 +78,7 @@ export default class SignupTypeSelector extends Vue {
     }
 
     .ledger-button {
-        border: solid 2px #e5e5e5;
+        border: solid 0.25rem #e5e5e5;
         background: none;
         color: inherit;
     }

--- a/src/views/SignupTypeSelector.vue
+++ b/src/views/SignupTypeSelector.vue
@@ -1,22 +1,22 @@
 <template>
     <div class="container">
         <small-page>
-            <div>
-                <PageHeader :progressIndicator="true" :numberSteps="6" :step="1">Add a Wallet</PageHeader>
-                <div class="page-body">
-                    <p>A Wallet is like a login and can contain one or more accounts, which you can use to send or receive Nimiq, pay online and create Cashlinks.</p>
-                    <button @click="createKeyguard" class="purple-background keyguard-icon">
-                        <h2>Create Wallet</h2>
-                        <p>Create a Wallet in our secure Nimiq Keyguard. This is the most convenient option.</p>
-                    </button>
-                    <button @click="createLedger" class="ledger-icon">
-                        <h2>Connect Hardware Wallet</h2>
-                        <p>Connect a Hardware Wallet like Ledger. This option requires a physical device. It is the most secure option.</p>
-                    </button>
-                </div>
-                <PageFooter>
-                    <a onclick="alert('Not yet implemented')">Already have a wallet?</a>
-                </PageFooter>
+    <div>
+        <PageHeader :progressIndicator="true" :numberSteps="6" :step="1">Add a Wallet</PageHeader>
+        <PageBody>
+            <p class="nq-text">A Wallet is like a login and can contain one or more accounts, which you can use to send or receive Nimiq, pay online and create Cashlinks.</p>
+            <button @click="createKeyguard" class="keyguard-button nq-bg-blue">
+                <h2 class="nq-h2">Create Wallet</h2>
+                <p class="nq-text">Create a Wallet in our secure Nimiq Keyguard. This is the most convenient option.</p>
+            </button>
+            <button @click="createLedger" class="ledger-button">
+                <h2 class="nq-h2">Connect Hardware Wallet</h2>
+                <p class="nq-text">Connect a Hardware Wallet like Ledger. This option requires a physical device. It is the most secure option.</p>
+            </button>
+        </PageBody>
+        <PageFooter>
+            <a class="nq-link" onclick="alert('Not yet implemented')" href="javascript:void(0);">Already have a wallet?</a>
+        </PageFooter>
             </div>
         </small-page>
         <a class="global-close" @click="close">Back to {{request.appName}}</a>
@@ -25,14 +25,14 @@
 
 <script lang="ts">
 import { Component, Emit, Vue } from 'vue-property-decorator';
-import { PageHeader, PageFooter, SmallPage } from '@nimiq/vue-components';
+import { PageHeader, PageBody, PageFooter, SmallPage } from '@nimiq/vue-components';
 import { ParsedSignupRequest } from '../lib/RequestTypes';
 import RpcApi from '../lib/RpcApi';
 import { CreateRequest as CreateRequest } from '@nimiq/keyguard-client';
 import { ResponseStatus, State as RpcState } from '@nimiq/rpc';
 import staticStore, { Static } from '../lib/StaticStore';
 
-@Component({components: {PageHeader, PageFooter, SmallPage}})
+@Component({components: {PageHeader, PageBody, PageFooter, SmallPage}})
 export default class SignupTypeSelector extends Vue {
     @Static private rpcState!: RpcState;
     @Static private request!: ParsedSignupRequest;
@@ -60,57 +60,28 @@ export default class SignupTypeSelector extends Vue {
 </script>
 
 <style scoped>
-    .page-body {
-        background: #fafafa;
-        overflow: auto;
-        padding-bottom: 2rem;
-    }
-
-    p {
-        margin: 4rem;
-        font-size: 2rem;
-        line-height: 1.3;
-        opacity: 0.7;
-    }
-
     button {
-        font-weight: normal;
-        text-transform: none;
+        display: block;
         text-align: left;
-        letter-spacing: normal;
         padding: 2rem;
         border-radius: 0.5rem;
 
-        margin: 0 4rem 2rem;
-        border: solid 2px #e5e5e5;
-        box-shadow: unset;
-        width: auto;
-        background: transparent;
-        position: relative;
-
-        max-width: unset;
-        height: auto;
-    }
-
-    button h2 {
-        font-size: 2.25rem;
-        line-height: 2.5rem;
-        font-weight: 600;
-        margin: 0 0 0.8rem;
-    }
-
-    button p {
-        margin: 0;
-    }
-
-    button.purple-background {
-        background: #724ceb;
-        color: white;
+        margin: 3rem 0;
         border: none;
+        position: relative;
+        font-family: inherit;
+
+        cursor: pointer;
     }
 
-    button.keyguard-icon::after,
-    button.ledger-icon::after {
+    .ledger-button {
+        border: solid 2px #e5e5e5;
+        background: none;
+        color: inherit;
+    }
+
+    button.keyguard-button::after,
+    button.ledger-button::after {
         content: '';
         display: block;
         background: #fafafa;
@@ -125,25 +96,17 @@ export default class SignupTypeSelector extends Vue {
         background-repeat: no-repeat;
     }
 
-    button.keyguard-icon::after {
+    button.keyguard-button::after {
         background-image: url('data:image/svg+xml,<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 24 28" style="enable-background:new 0 0 24 28;" xml:space="preserve"><path fill="%23F5AF2D" d="M15.45,9.57c-0.15-0.3-0.57-0.53-0.89-0.53H9.42c-0.32,0-0.72,0.23-0.89,0.53l-2.57,4.49 c-0.15,0.28-0.15,0.76,0,1.03l2.57,4.49c0.17,0.3,0.57,0.53,0.89,0.53h5.14c0.35,0,0.74-0.23,0.89-0.53l2.57-4.49 c0.17-0.28,0.17-0.76,0-1.03L15.45,9.57z M23.58,5.29C23.83,5.36,24,5.59,24,5.85c0,10-0.87,17.98-11.8,22.11 C12.13,27.99,12.07,28,12,28c-0.07,0-0.13-0.01-0.2-0.04C0.87,23.83,0,15.85,0,5.85c0-0.26,0.17-0.49,0.42-0.56 c0.08-0.02,8.46-2.35,11.16-5.12c0.21-0.22,0.61-0.22,0.83,0C15.12,2.94,23.49,5.27,23.58,5.29z"/></svg>');
         background-size: auto 3.5rem;
     }
 
-    button.ledger-icon::after {
+    button.ledger-button::after {
         background-image: url('data:image/svg+xml,<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 25 25" style="enable-background:new 0 0 25 25;" xml:space="preserve"><path fill="%23333745" d="M21.05,0H9.5V15.1H25l0-11.17C25,1.81,23.22,0,21.05,0"/><path fill="%23333745" d="M6.04,0H4.08C1.88,0,0,1.75,0,3.98v1.91h6.04V0z"/><rect fill="%23333745" y="9.21" width="6.08" height="5.92"/><path fill="%23333745" d="M18.92,25h1.97C23.11,25,25,23.24,25,21v-1.92h-6.08V25z"/><rect fill="%23333745" x="9.46" y="19.08" width="6.08" height="5.92"/><path fill="%23333745" d="M0,19.08V21c0,2.16,1.8,4,4.11,4h1.97v-5.92H0z"/></svg>');
         background-size: 3.125rem;
     }
 
     .page-footer {
-        padding: 3.5rem 4rem;
-        height: auto;
-    }
-
-    .page-footer a {
         font-size: 2rem;
-        color: #2a60dd;
-        text-decoration: underline;
-        cursor: pointer;
     }
 </style>

--- a/src/views/SignupTypeSelector.vue
+++ b/src/views/SignupTypeSelector.vue
@@ -62,13 +62,14 @@ export default class SignupTypeSelector extends Vue {
 </script>
 
 <style scoped>
-    button {
+    .keyguard-button,
+    .ledger-button {
         display: block;
         text-align: left;
         padding: 2rem;
         border-radius: 0.5rem;
 
-        margin: 3rem 0;
+        margin: 2.75rem 0;
         border: none;
         position: relative;
         font-family: inherit;

--- a/src/views/SignupTypeSelector.vue
+++ b/src/views/SignupTypeSelector.vue
@@ -87,7 +87,7 @@ export default class SignupTypeSelector extends Vue {
     button.ledger-button::after {
         content: '';
         display: block;
-        background: #fafafa;
+        background: var(--nimiq-card-bg);
         height: 5rem;
         width: 5rem;
         border-radius: 50%;

--- a/src/views/SimpleSuccess.vue
+++ b/src/views/SimpleSuccess.vue
@@ -1,12 +1,12 @@
 <template>
-    <div class="container">
-        <small-page>
+    <div class="container pad-bottom">
+        <SmallPage>
             <Success
                 :text="text"
                 :appName="request.appName"
                 @continue="done"
                 />
-        </small-page>
+        </SmallPage>
     </div>
 </template>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -817,10 +817,10 @@
   resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.0.11.tgz#7230365640663827fb115e0d6456222de3b1c5e3"
   integrity sha512-aSTQwsTeSH46ubRDHqB7x82Alq5a9PlMYJUgDVd/4ET1dMTLm+4sjaFiWho3+SjG2n5/v09XKlDUBFDaENYT6w==
 
-"@nimiq/style@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@nimiq/style/-/style-0.2.1.tgz#158e83481de867cbcccd7b4106aa0f1794354d3c"
-  integrity sha512-vmzEqsKPFG+5M7GIACpCwUztAGCW+Z0L0pfSy7buxh+RhdfzPCnTS+kIiZAtXDx2iEGwAzgY/LSzeOeAtrnzmQ==
+"@nimiq/style@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@nimiq/style/-/style-0.3.2.tgz#252d47a83d15ff3073f44343e7818970aafc3a00"
+  integrity sha512-mJSmqELaq3NsmNWoxQJWr/AWCV1vjxy/XqSle0q9wN0UH0u2OXyo3FAJuY0uCGH8FovUoTr89dELguzHBRZmVQ==
 
 "@nimiq/vue-components@https://github.com/nimiq/vue-components.git#build/accounts":
   version "0.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -817,10 +817,10 @@
   resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.0.11.tgz#7230365640663827fb115e0d6456222de3b1c5e3"
   integrity sha512-aSTQwsTeSH46ubRDHqB7x82Alq5a9PlMYJUgDVd/4ET1dMTLm+4sjaFiWho3+SjG2n5/v09XKlDUBFDaENYT6w==
 
-"@nimiq/style@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@nimiq/style/-/style-0.3.2.tgz#252d47a83d15ff3073f44343e7818970aafc3a00"
-  integrity sha512-mJSmqELaq3NsmNWoxQJWr/AWCV1vjxy/XqSle0q9wN0UH0u2OXyo3FAJuY0uCGH8FovUoTr89dELguzHBRZmVQ==
+"@nimiq/style@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@nimiq/style/-/style-0.3.3.tgz#e4f09e1e20fa36b46daf00761316ebfe5d9d9d5a"
+  integrity sha512-iBxCtSfCQXJFm0D//qvy6auWdkgHDLHIo2FaPPVXKKy/BBcxDiRsDRWB9rAsC2LHHNlRJ4BA1DU70eLHpn9XWw==
 
 "@nimiq/vue-components@https://github.com/nimiq/vue-components.git#build/accounts":
   version "0.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -817,10 +817,10 @@
   resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.0.11.tgz#7230365640663827fb115e0d6456222de3b1c5e3"
   integrity sha512-aSTQwsTeSH46ubRDHqB7x82Alq5a9PlMYJUgDVd/4ET1dMTLm+4sjaFiWho3+SjG2n5/v09XKlDUBFDaENYT6w==
 
-"@nimiq/style@^0.3.3":
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@nimiq/style/-/style-0.3.3.tgz#e4f09e1e20fa36b46daf00761316ebfe5d9d9d5a"
-  integrity sha512-iBxCtSfCQXJFm0D//qvy6auWdkgHDLHIo2FaPPVXKKy/BBcxDiRsDRWB9rAsC2LHHNlRJ4BA1DU70eLHpn9XWw==
+"@nimiq/style@^0.3.4":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@nimiq/style/-/style-0.3.4.tgz#dec68f59ba280830b39b1616653f04411905d14f"
+  integrity sha512-Xvxs/T8JiVTCXRnkuWE1a2b+fiQpdBypVtcQPUx6DJQx/SXSuNzhpszY/qugC2jRE4s5uYE9aU5+2kaxLcu5Jw==
 
 "@nimiq/vue-components@https://github.com/nimiq/vue-components.git#build/accounts":
   version "0.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -817,9 +817,14 @@
   resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.0.11.tgz#7230365640663827fb115e0d6456222de3b1c5e3"
   integrity sha512-aSTQwsTeSH46ubRDHqB7x82Alq5a9PlMYJUgDVd/4ET1dMTLm+4sjaFiWho3+SjG2n5/v09XKlDUBFDaENYT6w==
 
+"@nimiq/style@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@nimiq/style/-/style-0.2.1.tgz#158e83481de867cbcccd7b4106aa0f1794354d3c"
+  integrity sha512-vmzEqsKPFG+5M7GIACpCwUztAGCW+Z0L0pfSy7buxh+RhdfzPCnTS+kIiZAtXDx2iEGwAzgY/LSzeOeAtrnzmQ==
+
 "@nimiq/vue-components@https://github.com/nimiq/vue-components.git#build/accounts":
   version "0.1.0"
-  resolved "https://github.com/nimiq/vue-components.git#42073b5bc43daad6ee358734774f826f507d33e6"
+  resolved "https://github.com/nimiq/vue-components.git#f20f3c04e64a154d1a9530a02916e761bd7ceaf3"
   dependencies:
     vue "^2.5.17"
     vue-property-decorator "^7.0.0"


### PR DESCRIPTION
Resolves #48.

Use @nimiq/nimiq-style in Accounts Manager.

Also includes additions of `buttonText` and `disabled` props to the `Success.vue` component to enable `SignTransactionSuccess.vue` to use it.

Screenshots:
![screenshot from 2018-11-15 10-32-31](https://user-images.githubusercontent.com/1828163/48544108-3d544600-e8c3-11e8-85cc-11b313f1d657.png)
![screenshot from 2018-11-15 10-34-12](https://user-images.githubusercontent.com/1828163/48544129-4513ea80-e8c3-11e8-81b7-41a2ce3584f4.png)
![screenshot from 2018-11-15 10-34-46](https://user-images.githubusercontent.com/1828163/48544137-480edb00-e8c3-11e8-9184-b1b16f017e21.png)
![screenshot from 2018-11-15 10-36-00](https://user-images.githubusercontent.com/1828163/48544146-4ba26200-e8c3-11e8-936a-91259cd0e921.png)
