### PR TITLE
Use centralized Vue.$rpc methods

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,13 @@ import RpcApi from '@/lib/RpcApi';
 
 Vue.config.productionTip = false;
 
+Vue.prototype.$rpc = RpcApi;
+declare module 'vue/types/vue' {
+  interface Vue {
+    $rpc: typeof RpcApi;
+  }
+}
+
 new Vue({
   router,
   store,

--- a/src/views/ActiveAccountSelector.vue
+++ b/src/views/ActiveAccountSelector.vue
@@ -24,7 +24,6 @@ import { Component, Emit, Vue } from 'vue-property-decorator';
 import { AccountSelector, WalletSelector } from '@nimiq/vue-components';
 import { AccountInfo } from '../lib/AccountInfo';
 import { WalletInfo, WalletType } from '../lib/WalletInfo';
-import { RequestType } from '../lib/RequestTypes';
 import { State, Mutation } from 'vuex-class';
 
 @Component({components: {AccountSelector, WalletSelector}})

--- a/src/views/AddAccountSuccess.vue
+++ b/src/views/AddAccountSuccess.vue
@@ -28,13 +28,11 @@ import { AccountInfo } from '../lib/AccountInfo';
 import { State } from 'vuex-class';
 import { WalletStore } from '../lib/WalletStore';
 import { DeriveAddressResult } from '@nimiq/keyguard-client';
-import { ResponseStatus, State as RpcState } from '@nimiq/rpc';
 import { AddAccountRequest, AddAccountResult } from '@/lib/RequestTypes';
 import { Static } from '../lib/StaticStore';
 
 @Component({components: {PageHeader, PageBody, Account, SmallPage}})
 export default class AddAccountSuccess extends Vue {
-    @Static private rpcState!: RpcState;
     @Static private request!: AddAccountRequest;
     @State private keyguardResult!: DeriveAddressResult;
 
@@ -65,7 +63,7 @@ export default class AddAccountSuccess extends Vue {
             },
         };
 
-        this.rpcState.reply(ResponseStatus.OK, result);
+        this.$rpc.resolve(result);
     }
 
     private async saveResult(accountLabel: string) {

--- a/src/views/ChangePassphrase.vue
+++ b/src/views/ChangePassphrase.vue
@@ -3,10 +3,9 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import { ParsedChangePassphraseRequest } from '../lib/RequestTypes';
-import RpcApi from '../lib/RpcApi';
 import { SimpleRequest } from '@nimiq/keyguard-client';
 import { WalletStore } from '@/lib/WalletStore';
-import staticStore, { Static } from '../lib/StaticStore';
+import { Static } from '../lib/StaticStore';
 
 @Component
 export default class ChangePassphrase extends Vue {
@@ -22,7 +21,7 @@ export default class ChangePassphrase extends Vue {
             keyLabel: wallet.label,
         };
 
-        const client = RpcApi.createKeyguardClient(this.$store, staticStore);
+        const client = this.$rpc.createKeyguardClient();
         client.changePassphrase(request).catch(console.error); // TODO: proper error handling
     }
 }

--- a/src/views/Checkout.vue
+++ b/src/views/Checkout.vue
@@ -19,17 +19,15 @@
 import { Component, Emit, Vue } from 'vue-property-decorator';
 import { PaymentInfoLine, SmallPage } from '@nimiq/vue-components';
 import { ParsedCheckoutRequest } from '../lib/RequestTypes';
-import { State as RpcState, ResponseStatus } from '@nimiq/rpc';
 import { Static } from '../lib/StaticStore';
 
 @Component({components: {PaymentInfoLine, SmallPage}})
 export default class Checkout extends Vue {
-    @Static private rpcState!: RpcState;
     @Static private request!: ParsedCheckoutRequest;
 
     @Emit()
     private close() {
-        this.rpcState.reply(ResponseStatus.ERROR, new Error('CANCEL'));
+        this.$rpc.reject(new Error('CANCEL'));
     }
 }
 </script>

--- a/src/views/CheckoutOverview.vue
+++ b/src/views/CheckoutOverview.vue
@@ -18,7 +18,6 @@ import CheckoutDetails from '../components/CheckoutDetails.vue';
 import { AccountInfo } from '../lib/AccountInfo';
 import { WalletInfo } from '../lib/WalletInfo';
 import { RequestType, ParsedCheckoutRequest } from '../lib/RequestTypes';
-import RpcApi from '../lib/RpcApi';
 import staticStore, { Static } from '../lib/StaticStore';
 import Network from '../components/Network.vue';
 
@@ -79,7 +78,7 @@ export default class CheckoutOverview extends Vue {
         });
         staticStore.keyguardRequest = storedRequest;
 
-        const client = RpcApi.createKeyguardClient(this.$store, staticStore);
+        const client = this.$rpc.createKeyguardClient();
         client.signTransaction(request).catch(console.error); // TODO: proper error handling
     }
 

--- a/src/views/CheckoutTransmission.vue
+++ b/src/views/CheckoutTransmission.vue
@@ -18,7 +18,6 @@ import { Component, Vue } from 'vue-property-decorator';
 import Network from '@/components/Network.vue';
 import { SignTransactionResult } from '@/lib/RequestTypes';
 import CheckoutDetails from '../components/CheckoutDetails.vue';
-import { State as RpcState, ResponseStatus } from '@nimiq/rpc';
 import {
     SignTransactionRequest as KSignTransactionRequest,
     SignTransactionResult as KSignTransactionResult,
@@ -30,7 +29,6 @@ import { PageFooter } from '@nimiq/vue-components';
 
 @Component({components: {PageFooter, Network, CheckoutDetails, Success}})
 export default class CheckoutTransmission extends Vue {
-    @Static private rpcState!: RpcState;
     // The stored keyguardRequest does not have Uint8Array, only regular arrays
     @Static private keyguardRequest!: KSignTransactionRequest;
     @State private keyguardResult!: KSignTransactionResult;
@@ -45,7 +43,7 @@ export default class CheckoutTransmission extends Vue {
     }
 
     private done() {
-        this.rpcState.reply(ResponseStatus.OK, this.result);
+        this.$rpc.resolve(this.result!);
     }
 }
 </script>

--- a/src/views/ErrorHandler.vue
+++ b/src/views/ErrorHandler.vue
@@ -12,7 +12,7 @@ export default class ErrorHandler extends Vue {
         if (this.keyguardResult instanceof Error) {
             if (!this.requestSpecificErrors()) {
                 // TODO proper Error Handling
-                console.log(this.keyguardResult);
+                // console.log(this.keyguardResult);
                 this.$rpc.reject(this.keyguardResult);
             }
         }

--- a/src/views/ErrorHandler.vue
+++ b/src/views/ErrorHandler.vue
@@ -3,12 +3,9 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import { State } from 'vuex-class';
-import { ResponseStatus, State as RpcState } from '@nimiq/rpc';
-import { Static } from '@/lib/StaticStore';
 
 @Component
 export default class ErrorHandler extends Vue {
-    @Static protected rpcState!: RpcState;
     @State protected keyguardResult!: Error;
 
     public async created() {
@@ -16,7 +13,7 @@ export default class ErrorHandler extends Vue {
             if (!this.requestSpecificErrors()) {
                 // TODO proper Error Handling
                 console.log(this.keyguardResult);
-                this.rpcState.reply(ResponseStatus.ERROR, this.keyguardResult);
+                this.$rpc.reject(this.keyguardResult);
             }
         }
     }

--- a/src/views/Export.vue
+++ b/src/views/Export.vue
@@ -3,10 +3,9 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import { ParsedExportRequest } from '../lib/RequestTypes';
-import RpcApi from '../lib/RpcApi';
 import { SimpleRequest } from '@nimiq/keyguard-client';
 import { WalletStore } from '@/lib/WalletStore';
-import staticStore, { Static } from '../lib/StaticStore';
+import { Static } from '../lib/StaticStore';
 
 @Component
 export default class Export extends Vue {
@@ -22,7 +21,7 @@ export default class Export extends Vue {
             keyLabel: wallet.label,
         };
 
-        const client = RpcApi.createKeyguardClient(this.$store, staticStore);
+        const client = this.$rpc.createKeyguardClient();
         client.export(request).catch(console.error); // TODO: proper error handling
     }
 }

--- a/src/views/ExportFile.vue
+++ b/src/views/ExportFile.vue
@@ -3,10 +3,9 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import { ParsedExportFileRequest } from '../lib/RequestTypes';
-import RpcApi from '../lib/RpcApi';
 import { SimpleRequest } from '@nimiq/keyguard-client';
 import { WalletStore } from '@/lib/WalletStore';
-import staticStore, { Static } from '../lib/StaticStore';
+import { Static } from '../lib/StaticStore';
 
 @Component
 export default class ExportFile extends Vue {
@@ -22,7 +21,7 @@ export default class ExportFile extends Vue {
             keyLabel: wallet.label,
         };
 
-        const client = RpcApi.createKeyguardClient(this.$store, staticStore);
+        const client = this.$rpc.createKeyguardClient();
         client.exportFile(request).catch(console.error); // TODO: proper error handling
     }
 }

--- a/src/views/ExportWords.vue
+++ b/src/views/ExportWords.vue
@@ -3,10 +3,9 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import { ParsedExportWordsRequest } from '../lib/RequestTypes';
-import RpcApi from '../lib/RpcApi';
 import { SimpleRequest } from '@nimiq/keyguard-client';
 import { WalletStore } from '@/lib/WalletStore';
-import staticStore, { Static } from '../lib/StaticStore';
+import { Static } from '../lib/StaticStore';
 
 @Component
 export default class ExportWords extends Vue {
@@ -22,7 +21,7 @@ export default class ExportWords extends Vue {
             keyLabel: wallet.label,
         };
 
-        const client = RpcApi.createKeyguardClient(this.$store, staticStore);
+        const client = this.$rpc.createKeyguardClient();
         client.exportWords(request).catch(console.error); // TODO: proper error handling
     }
 }

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -3,9 +3,8 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import { ParsedLoginRequest } from '../lib/RequestTypes';
-import RpcApi from '../lib/RpcApi';
 import { ImportRequest } from '@nimiq/keyguard-client';
-import staticStore, { Static } from '../lib/StaticStore';
+import { Static } from '../lib/StaticStore';
 
 @Component
 export default class Login extends Vue {
@@ -18,7 +17,7 @@ export default class Login extends Vue {
             requestedKeyPaths: [`m/44'/242'/0'/0'`],
         };
 
-        const client = RpcApi.createKeyguardClient(this.$store, staticStore);
+        const client = this.$rpc.createKeyguardClient();
         client.import(request).catch(console.error); // TODO: proper error handling
     }
 }

--- a/src/views/LoginSuccess.vue
+++ b/src/views/LoginSuccess.vue
@@ -31,7 +31,6 @@ import { ParsedLoginRequest, LoginResult } from '../lib/RequestTypes';
 import { State } from 'vuex-class';
 import { WalletInfo, WalletType } from '../lib/WalletInfo';
 import { ImportResult, KeyguardClient } from '@nimiq/keyguard-client';
-import { ResponseStatus, State as RpcState } from '@nimiq/rpc';
 import { AccountInfo } from '@/lib/AccountInfo';
 import { WalletStore } from '@/lib/WalletStore';
 import { Static } from '@/lib/StaticStore';
@@ -41,7 +40,6 @@ import Network from '@/components/Network.vue';
 @Component({components: {PageHeader, PageBody, LabelInput, AccountList, Network, PageFooter, SmallPage}})
 export default class LoginSuccess extends Vue {
     @Static private request!: ParsedLoginRequest;
-    @Static private rpcState!: RpcState;
     @State private keyguardResult!: ImportResult;
 
     private keyguard!: KeyguardClient;
@@ -220,7 +218,7 @@ export default class LoginSuccess extends Vue {
     @Emit()
     private done() {
         if (!this.result) throw new Error('Result not set');
-        this.rpcState.reply(ResponseStatus.OK, this.result);
+        this.$rpc.resolve(this.result);
     }
 
     private get walletIconClass(): string {

--- a/src/views/Logout.vue
+++ b/src/views/Logout.vue
@@ -3,10 +3,9 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import { ParsedLogoutRequest } from '../lib/RequestTypes';
-import RpcApi from '../lib/RpcApi';
 import { SimpleRequest } from '@nimiq/keyguard-client';
 import { WalletStore } from '@/lib/WalletStore';
-import staticStore, { Static } from '../lib/StaticStore';
+import { Static } from '../lib/StaticStore';
 
 @Component
 export default class Logout extends Vue {
@@ -22,7 +21,7 @@ export default class Logout extends Vue {
             keyLabel: wallet.label,
         };
 
-        const client = RpcApi.createKeyguardClient(this.$store, staticStore);
+        const client = this.$rpc.createKeyguardClient();
         client.remove(request).catch(console.error); // TODO: proper error handling
     }
 }

--- a/src/views/LogoutSuccess.vue
+++ b/src/views/LogoutSuccess.vue
@@ -14,7 +14,6 @@
 import { Component, Emit, Vue } from 'vue-property-decorator';
 import { ParsedLogoutRequest } from '../lib/RequestTypes';
 import { State } from 'vuex-class';
-import { ResponseStatus, State as RpcState } from '@nimiq/rpc';
 import { SmallPage } from '@nimiq/vue-components';
 import { SimpleResult } from '@nimiq/keyguard-client';
 import { WalletStore } from '@/lib/WalletStore';
@@ -24,7 +23,6 @@ import Success from '../components/Success.vue';
 @Component({components: {Success, SmallPage}})
 export default class LogoutSuccess extends Vue {
     @Static private request!: ParsedLogoutRequest;
-    @Static private rpcState!: RpcState;
     @State private keyguardResult!: SimpleResult;
 
     public mounted() {
@@ -33,7 +31,7 @@ export default class LogoutSuccess extends Vue {
 
     @Emit()
     private done() {
-        this.rpcState.reply(ResponseStatus.OK, this.keyguardResult);
+        this.$rpc.resolve(this.keyguardResult);
     }
 }
 </script>

--- a/src/views/Rename.vue
+++ b/src/views/Rename.vue
@@ -37,7 +37,6 @@ import { Component, Vue, Emit } from 'vue-property-decorator';
 import { AccountList, LabelInput, SmallPage, PageHeader, PageBody, PageFooter } from '@nimiq/vue-components';
 import { ParsedRenameRequest, RenameResult } from '../lib/RequestTypes';
 import Success from '../components/Success.vue';
-import { ResponseStatus, State as RpcState } from '@nimiq/rpc';
 import { WalletInfo, WalletType } from '../lib/WalletInfo';
 import { WalletStore } from '@/lib/WalletStore';
 import { Static } from '../lib/StaticStore';
@@ -62,7 +61,6 @@ import { Static } from '../lib/StaticStore';
 }})
 export default class Rename extends Vue {
     @Static private request!: ParsedRenameRequest;
-    @Static private rpcState!: RpcState;
 
     private wallet: WalletInfo | null = null;
     private labelsStored: boolean = false;
@@ -129,12 +127,12 @@ export default class Rename extends Vue {
             })),
         } as RenameResult;
 
-        this.rpcState.reply(ResponseStatus.OK, result);
+        this.$rpc.resolve(result);
     }
 
     @Emit()
     private close() {
-        this.rpcState.reply(ResponseStatus.ERROR, new Error('CANCEL'));
+        this.$rpc.reject(new Error('CANCEL'));
     }
 }
 </script>

--- a/src/views/SignMessageOverview.vue
+++ b/src/views/SignMessageOverview.vue
@@ -23,15 +23,14 @@
 <script lang="ts">
 import { Component, Emit } from 'vue-property-decorator';
 import { Getter } from 'vuex-class';
-import { Amount, Account, PageHeader, PageBody, PageFooter } from '@nimiq/vue-components';
-import { ResponseStatus } from '@nimiq/rpc';
+import { Account, PageHeader, PageBody, PageFooter } from '@nimiq/vue-components';
 import { AccountInfo } from '../lib/AccountInfo';
 import { WalletInfo } from '../lib/WalletInfo';
 import { RequestType } from '../lib/RequestTypes';
 import Utf8Tools from '../lib/Utf8Tools';
 import SignMessage from '@/views/SignMessage.vue';
 
-@Component({components: {Amount, Account, PageHeader, PageBody, PageFooter}})
+@Component({components: {Account, PageHeader, PageBody, PageFooter}})
 export default class SignMessageOverview extends SignMessage {
     @Getter private activeWallet!: WalletInfo | undefined;
     @Getter private activeAccount!: AccountInfo | undefined;

--- a/src/views/SignMessageSuccess.vue
+++ b/src/views/SignMessageSuccess.vue
@@ -8,9 +8,7 @@
 
 <script lang="ts">
 import { Component, Emit, Vue } from 'vue-property-decorator';
-import { SmallPage } from '@nimiq/vue-components';
 import { State } from 'vuex-class';
-import { ResponseStatus, State as RpcState } from '@nimiq/rpc';
 import { SignMessageResult, SignMessageRequest } from '../lib/RequestTypes';
 import {
     SignMessageRequest as KSignMessageRequest,
@@ -18,12 +16,10 @@ import {
 } from '@nimiq/keyguard-client';
 import { Static } from '@/lib/StaticStore';
 import Success from '../components/Success.vue';
-import Utf8Tools from '../lib/Utf8Tools';
 
-@Component({components: {SmallPage, Success}})
+@Component({components: {Success}})
 export default class SimpleSuccess extends Vue {
     @Static private request!: SignMessageRequest;
-    @Static private rpcState!: RpcState;
     // The stored keyguardRequest does not have Uint8Array, only regular arrays
     @Static private keyguardRequest!: KSignMessageRequest;
     @State private keyguardResult!: KSignMessageResult;
@@ -37,7 +33,7 @@ export default class SimpleSuccess extends Vue {
             data: this.keyguardResult.data,
         };
 
-        this.rpcState.reply(ResponseStatus.OK, result);
+        this.$rpc.resolve(result);
     }
 }
 </script>

--- a/src/views/SignTransaction.vue
+++ b/src/views/SignTransaction.vue
@@ -4,7 +4,6 @@
 import { Component, Vue } from 'vue-property-decorator';
 import { ParsedSignTransactionRequest } from '../lib/RequestTypes';
 import { SignTransactionRequest as KSignTransactionRequest } from '@nimiq/keyguard-client';
-import RpcApi from '../lib/RpcApi';
 import { WalletStore } from '@/lib/WalletStore';
 import staticStore, { Static } from '../lib/StaticStore';
 
@@ -54,7 +53,7 @@ export default class SignTransaction extends Vue {
         });
         staticStore.keyguardRequest = storedRequest;
 
-        const client = RpcApi.createKeyguardClient(this.$store, staticStore);
+        const client = this.$rpc.createKeyguardClient();
         client.signTransaction(request).catch(console.error); // TODO: proper error handling
     }
 }

--- a/src/views/SignTransactionSuccess.vue
+++ b/src/views/SignTransactionSuccess.vue
@@ -17,7 +17,6 @@ import { Component, Vue } from 'vue-property-decorator';
 import Network from '@/components/Network.vue';
 import { SmallPage } from '@nimiq/vue-components';
 import { SignTransactionResult } from '../lib/RequestTypes';
-import { State as RpcState, ResponseStatus } from '@nimiq/rpc';
 import {
     SignTransactionRequest as KSignTransactionRequest,
     SignTransactionResult as KSignTransactionResult,
@@ -28,7 +27,6 @@ import Success from '../components/Success.vue';
 
 @Component({components: {Network, SmallPage, Success}})
 export default class SignTransactionSuccess extends Vue {
-    @Static private rpcState!: RpcState;
     // The stored keyguardRequest does not have Uint8Array, only regular arrays
     @Static private keyguardRequest!: KSignTransactionRequest;
     @State private keyguardResult!: KSignTransactionResult;
@@ -43,7 +41,7 @@ export default class SignTransactionSuccess extends Vue {
     }
 
     private done() {
-        this.rpcState.reply(ResponseStatus.OK, this.result);
+        this.$rpc.resolve(this.result!);
     }
 }
 </script>

--- a/src/views/SignupSuccess.vue
+++ b/src/views/SignupSuccess.vue
@@ -30,13 +30,10 @@ import { WalletInfo, WalletType } from '../lib/WalletInfo';
 import { State, Getter } from 'vuex-class';
 import { WalletStore } from '../lib/WalletStore';
 import { CreateResult } from '@nimiq/keyguard-client';
-import { ResponseStatus, State as RpcState } from '@nimiq/rpc';
 import { SignupResult } from '@/lib/RequestTypes';
-import { Static } from '../lib/StaticStore';
 
 @Component({components: {PageHeader, PageBody, Account, LabelInput, SmallPage}})
 export default class SignupSuccess extends Vue {
-    @Static private rpcState!: RpcState;
     @State private keyguardResult!: CreateResult;
     @State private activeAccountPath!: string;
     @Getter private hasWallets!: boolean;
@@ -77,7 +74,7 @@ export default class SignupSuccess extends Vue {
             },
         };
 
-        this.rpcState.reply(ResponseStatus.OK, result);
+        this.$rpc.resolve(result);
     }
 
     private async saveResult(walletLabel: string, accountLabel: string) {

--- a/src/views/SignupTypeSelector.vue
+++ b/src/views/SignupTypeSelector.vue
@@ -29,18 +29,15 @@
 import { Component, Emit, Vue } from 'vue-property-decorator';
 import { PageHeader, PageBody, PageFooter, SmallPage } from '@nimiq/vue-components';
 import { ParsedSignupRequest } from '../lib/RequestTypes';
-import RpcApi from '../lib/RpcApi';
 import { CreateRequest as CreateRequest } from '@nimiq/keyguard-client';
-import { ResponseStatus, State as RpcState } from '@nimiq/rpc';
-import staticStore, { Static } from '../lib/StaticStore';
+import { Static } from '../lib/StaticStore';
 
 @Component({components: {PageHeader, PageBody, PageFooter, SmallPage}})
 export default class SignupTypeSelector extends Vue {
-    @Static private rpcState!: RpcState;
     @Static private request!: ParsedSignupRequest;
 
     public createKeyguard() {
-        const client = RpcApi.createKeyguardClient(this.$store, staticStore);
+        const client = this.$rpc.createKeyguardClient();
 
         const request: CreateRequest = {
             appName: this.request.appName,
@@ -56,7 +53,7 @@ export default class SignupTypeSelector extends Vue {
 
     @Emit()
     private close() {
-        this.rpcState.reply(ResponseStatus.ERROR, new Error('CANCEL'));
+        this.$rpc.reject(new Error('CANCEL'));
     }
 }
 </script>

--- a/src/views/SimpleSuccess.vue
+++ b/src/views/SimpleSuccess.vue
@@ -14,17 +14,15 @@
 import { Component, Emit, Vue } from 'vue-property-decorator';
 import { SmallPage } from '@nimiq/vue-components';
 import { State } from 'vuex-class';
-import { ResponseStatus, State as RpcState } from '@nimiq/rpc';
-import { RpcRequest } from '../lib/RequestTypes';
-import { RpcResult } from '@nimiq/keyguard-client';
-import staticStore, { Static } from '@/lib/StaticStore';
+import { RpcRequest, SimpleResult } from '../lib/RequestTypes';
+import { SimpleResult as KSimpleResult } from '@nimiq/keyguard-client';
+import { Static } from '@/lib/StaticStore';
 import Success from '../components/Success.vue';
 
 @Component({components: {SmallPage, Success}})
 export default class SimpleSuccess extends Vue {
     @Static private request!: RpcRequest;
-    @Static private rpcState!: RpcState;
-    @State private keyguardResult!: RpcResult;
+    @State private keyguardResult!: KSimpleResult;
 
     get text() {
         switch (this.$route.name) {
@@ -43,7 +41,7 @@ export default class SimpleSuccess extends Vue {
 
     @Emit()
     private done() {
-        this.rpcState.reply(ResponseStatus.OK, this.keyguardResult);
+        this.$rpc.resolve(this.keyguardResult as SimpleResult);
     }
 }
 </script>


### PR DESCRIPTION
To enable both secondary requests (e.g. importing an account during checkout) and iOS cookie writing, we centralize the replying to the caller into the `RpcApi` class and package all `@nimiq/rpc` dependencies there.

This removes a lot of dependencies from all views.