### PR TITLE
Use SignupErrorHandler

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -132,12 +132,12 @@ export default new Router({
           component: CheckoutTransmission,
           name: `${RequestType.CHECKOUT}-success`,
         },
-        {
-          path: 'error',
-          component: CheckoutErrorHandler,
-          name: `${RequestType.CHECKOUT}-error`,
-        },
       ],
+    },
+    {
+      path: `/${RequestType.CHECKOUT}-error`,
+      component: CheckoutErrorHandler,
+      name: `${RequestType.CHECKOUT}-error`,
     },
     {
       path: `/${RequestType.SIGNUP}`,

--- a/src/router.ts
+++ b/src/router.ts
@@ -8,6 +8,7 @@ import CheckoutOverview from './views/CheckoutOverview.vue';
 import CheckoutTransmission from './views/CheckoutTransmission.vue';
 import SignupTypeSelector from './views/SignupTypeSelector.vue';
 import SignupSuccess from './views/SignupSuccess.vue';
+import SignupErrorHandler from './views/SignupErrorHandler.vue';
 import Login from './views/Login.vue';
 import LoginSuccess from './views/LoginSuccess.vue';
 import ExportFile from './views/ExportFile.vue';
@@ -39,7 +40,7 @@ export function keyguardResponseRouter(
     case KeyguardCommand.CREATE:
       return {
         resolve: `${RequestType.SIGNUP}-success`,
-        reject: RequestType.SIGNUP,
+        reject: `${RequestType.SIGNUP}-error`,
       };
     case KeyguardCommand.IMPORT:
       return {
@@ -147,6 +148,11 @@ export default new Router({
       path: `/${RequestType.SIGNUP}/success`,
       component: SignupSuccess,
       name: `${RequestType.SIGNUP}-success`,
+    },
+    {
+      path: `/${RequestType.SIGNUP}/error`,
+      component: SignupErrorHandler,
+      name: `${RequestType.SIGNUP}-error`,
     },
     {
       path: `/${RequestType.LOGIN}`,

--- a/src/views/SignupErrorHandler.vue
+++ b/src/views/SignupErrorHandler.vue
@@ -1,0 +1,19 @@
+<template></template>
+
+<script lang="ts">
+import { Component } from 'vue-property-decorator';
+import ErrorHandler from './ErrorHandler.vue';
+import { RequestType } from '@/lib/RequestTypes';
+
+@Component
+export default class SignupErrorHandler extends ErrorHandler {
+    protected requestSpecificErrors(): boolean {
+        if (this.keyguardResult instanceof Error
+            && this.keyguardResult.message === 'Request aborted') {
+            this.$router.push({name: RequestType.SIGNUP});
+            return true;
+        }
+        return false;
+    }
+}
+</script>


### PR DESCRIPTION
It only handles the back button in the Keyguard, but now it adheres to the error handling convention.

The CheckoutErrorHandler is moved out from Checkout's children, to not render the payment-info-line and the page while processing an error.