### PR TITLE
Switch from import to create and vice-versa

### DIFF
--- a/src/lib/RequestTypes.ts
+++ b/src/lib/RequestTypes.ts
@@ -134,7 +134,7 @@ export interface SignupResult {
     walletId: string;
     label: string;
     type: WalletType;
-    account: Array<{
+    accounts: Array<{
         address: string;
         label: string;
     }>;

--- a/src/lib/RequestTypes.ts
+++ b/src/lib/RequestTypes.ts
@@ -134,10 +134,10 @@ export interface SignupResult {
     walletId: string;
     label: string;
     type: WalletType;
-    account: {
+    account: Array<{
         address: string;
         label: string;
-    };
+    }>;
 }
 
 export interface LoginRequest {

--- a/src/router.ts
+++ b/src/router.ts
@@ -16,6 +16,7 @@ const SignupErrorHandler      = () => import(/* webpackChunkName: "signup" */ '.
 
 const Login                   = () => import(/* webpackChunkName: "login" */ './views/Login.vue');
 const LoginSuccess            = () => import(/* webpackChunkName: "login" */ './views/LoginSuccess.vue');
+const LoginErrorHandler       = () => import(/* webpackChunkName: "login" */ './views/LoginErrorHandler.vue');
 
 // const ExportFile              = () => import(/* webpackChunkName: "export" */ './views/ExportFile.vue');
 // const ExportWords             = () => import(/* webpackChunkName: "export" */ './views/ExportWords.vue');
@@ -60,7 +61,7 @@ export function keyguardResponseRouter(
     case KeyguardCommand.IMPORT:
       return {
         resolve: `${RequestType.LOGIN}-success`,
-        reject: 'default-error',
+        reject: `${RequestType.LOGIN}-error`,
       };
     case KeyguardCommand.REMOVE:
       return {
@@ -178,6 +179,11 @@ export default new Router({
       path: `/${RequestType.LOGIN}/success`,
       component: LoginSuccess,
       name: `${RequestType.LOGIN}-success`,
+    },
+    {
+      path: `/${RequestType.LOGIN}/error`,
+      component: LoginErrorHandler,
+      name: `${RequestType.LOGIN}-error`,
     },
     // {
     //   path: `/${RequestType.EXPORT_FILE}`,

--- a/src/views/LoginErrorHandler.vue
+++ b/src/views/LoginErrorHandler.vue
@@ -9,7 +9,7 @@ import { RequestType } from '@/lib/RequestTypes';
 export default class LoginErrorHandler extends ErrorHandler {
     protected requestSpecificErrors(): boolean {
         if (this.keyguardResult instanceof Error
-            && this.keyguardResult.message === 'GO_CREATE') {
+            && this.keyguardResult.message === 'GOTO_CREATE') {
             this.$router.push({name: RequestType.SIGNUP});
             return true;
         }

--- a/src/views/LoginErrorHandler.vue
+++ b/src/views/LoginErrorHandler.vue
@@ -1,0 +1,19 @@
+<template></template>
+
+<script lang="ts">
+import { Component } from 'vue-property-decorator';
+import ErrorHandler from './ErrorHandler.vue';
+import { RequestType } from '@/lib/RequestTypes';
+
+@Component
+export default class LoginErrorHandler extends ErrorHandler {
+    protected requestSpecificErrors(): boolean {
+        if (this.keyguardResult instanceof Error
+            && this.keyguardResult.message === 'GO_CREATE') {
+            this.$router.push({name: RequestType.SIGNUP});
+            return true;
+        }
+        return false;
+    }
+}
+</script>

--- a/src/views/SignupSuccess.vue
+++ b/src/views/SignupSuccess.vue
@@ -68,7 +68,7 @@ export default class SignupSuccess extends Vue {
             walletId: this.keyguardResult.keyId,
             label: this.walletLabel,
             type: WalletType.BIP39, // FIXME: Adapt when adding Ledger
-            account: [{
+            accounts: [{
                 address: this.createdAddress!.toUserFriendlyAddress(),
                 label: this.accountLabel,
             }],

--- a/src/views/SignupSuccess.vue
+++ b/src/views/SignupSuccess.vue
@@ -68,10 +68,10 @@ export default class SignupSuccess extends Vue {
             walletId: this.keyguardResult.keyId,
             label: this.walletLabel,
             type: WalletType.BIP39, // FIXME: Adapt when adding Ledger
-            account: {
+            account: [{
                 address: this.createdAddress!.toUserFriendlyAddress(),
                 label: this.accountLabel,
-            },
+            }],
         };
 
         this.$rpc.resolve(result);

--- a/src/views/SignupTypeSelector.vue
+++ b/src/views/SignupTypeSelector.vue
@@ -14,7 +14,7 @@
                 </button>
             </PageBody>
             <PageFooter>
-                <a class="nq-link" onclick="alert('Not yet implemented')" href="javascript:void(0);">Already have a wallet?</a>
+                <a class="nq-link" @click="login" href="javascript:void(0);">Already have a wallet?</a>
             </PageFooter>
         </SmallPage>
 
@@ -29,7 +29,7 @@
 import { Component, Emit, Vue } from 'vue-property-decorator';
 import { PageHeader, PageBody, PageFooter, SmallPage } from '@nimiq/vue-components';
 import { ParsedSignupRequest } from '../lib/RequestTypes';
-import { CreateRequest as CreateRequest } from '@nimiq/keyguard-client';
+import { CreateRequest as CreateRequest, ImportRequest as ImportRequest } from '@nimiq/keyguard-client';
 import { Static } from '../lib/StaticStore';
 
 @Component({components: {PageHeader, PageBody, PageFooter, SmallPage}})
@@ -49,6 +49,18 @@ export default class SignupTypeSelector extends Vue {
 
     public createLedger() {
         alert('Ledger-adding not yet implemented');
+    }
+
+    public login() {
+        const client = this.$rpc.createKeyguardClient();
+
+        const request: ImportRequest = {
+            appName: this.request.appName,
+            defaultKeyPath: `m/44'/242'/0'/0'`,
+            requestedKeyPaths: [`m/44'/242'/0'/0'`],
+        };
+
+        client.import(request).catch(console.log); // TODO: proper error handling
     }
 
     @Emit()

--- a/src/views/SignupTypeSelector.vue
+++ b/src/views/SignupTypeSelector.vue
@@ -29,7 +29,7 @@
 import { Component, Emit, Vue } from 'vue-property-decorator';
 import { PageHeader, PageBody, PageFooter, SmallPage } from '@nimiq/vue-components';
 import { ParsedSignupRequest } from '../lib/RequestTypes';
-import { CreateRequest as CreateRequest, ImportRequest as ImportRequest } from '@nimiq/keyguard-client';
+import { CreateRequest, ImportRequest } from '@nimiq/keyguard-client';
 import { Static } from '../lib/StaticStore';
 
 @Component({components: {PageHeader, PageBody, PageFooter, SmallPage}})


### PR DESCRIPTION
Allows the user to click the 'Already have a wallet?' and 'Don't have a wallet yet?' buttons in Create (Accounts) and Import (Keyguard).

Needs https://github.com/nimiq/keyguard-next/pull/126