### PR TITLE
Network improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     },
     "dependencies": {
         "@nimiq/keyguard-client": "^0.0.23",
-        "@nimiq/network-client": "^0.0.9",
+        "@nimiq/network-client": "^0.1.0",
         "@nimiq/rpc": "^0.0.11",
         "@nimiq/style": "^0.3.4",
         "@nimiq/utils": "^0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -634,9 +634,10 @@
   dependencies:
     "@nimiq/rpc" "^0.0.10"
 
-"@nimiq/network-client@^0.0.9":
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/@nimiq/network-client/-/network-client-0.0.9.tgz#d319fcc8711f8bd2da2b2040135dc24c31f657bc"
+"@nimiq/network-client@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@nimiq/network-client/-/network-client-0.1.0.tgz#80344ab0b601a312e7869dafdf1103cd719a38ff"
+  integrity sha512-uu6F1dfDmdCSADU9Y3gbGAyKaGsduHmTnT1cn4crHHRT0rMzfqTdZASyxy/DsMGqb3hQRPxLq0VOfiLJH7hvLQ==
   dependencies:
     "@nimiq/rpc-events" "^0.0.5"
 


### PR DESCRIPTION
- use same static NetworkClient singleton instance across all Network components to avoid the need to establish consensus multiple times
- when Network component gets destroyed, free up event listeners to avoid memory leak
- define event names as enum
