### PR TITLE
Enable page refresh at every step

### DIFF
--- a/client/AccountsClient.ts
+++ b/client/AccountsClient.ts
@@ -1,5 +1,5 @@
 import {
-    UrlEncodedPopupBehavior,
+    PopupRequestBehavior,
     IFrameRequestBehavior,
     RequestBehavior,
     RedirectRequestBehavior,
@@ -55,7 +55,7 @@ export default class AccountsClient {
 
     constructor(endpoint: string = AccountsClient.DEFAULT_ENDPOINT, defaultBehavior?: RequestBehavior) {
         this._endpoint = endpoint;
-        this._defaultBehavior = defaultBehavior || new UrlEncodedPopupBehavior(
+        this._defaultBehavior = defaultBehavior || new PopupRequestBehavior(
             `left=${window.innerWidth / 2 - 500},top=50,width=1000,height=900,location=yes,dependent=yes`);
         this._iframeBehavior = new IFrameRequestBehavior();
 

--- a/client/AccountsClient.ts
+++ b/client/AccountsClient.ts
@@ -1,5 +1,5 @@
 import {
-    PopupRequestBehavior,
+    UrlEncodedPopupBehavior,
     IFrameRequestBehavior,
     RequestBehavior,
     RedirectRequestBehavior,
@@ -55,7 +55,7 @@ export default class AccountsClient {
 
     constructor(endpoint: string = AccountsClient.DEFAULT_ENDPOINT, defaultBehavior?: RequestBehavior) {
         this._endpoint = endpoint;
-        this._defaultBehavior = defaultBehavior || new PopupRequestBehavior(
+        this._defaultBehavior = defaultBehavior || new UrlEncodedPopupBehavior(
             `left=${window.innerWidth / 2 - 500},top=50,width=1000,height=900,location=yes,dependent=yes`);
         this._iframeBehavior = new IFrameRequestBehavior();
 

--- a/client/RequestBehavior.ts
+++ b/client/RequestBehavior.ts
@@ -1,5 +1,5 @@
 import { RequestType } from '../src/lib/RequestTypes';
-import * as Rpc from '@nimiq/rpc';
+import { PostMessageRpcClient, RedirectRpcClient } from '@nimiq/rpc';
 
 export class RequestBehavior {
     public static getAllowedOrigin(endpoint: string) {
@@ -51,7 +51,7 @@ export class RedirectRequestBehavior extends RequestBehavior {
     public async request(endpoint: string, command: RequestType, args: any[]): Promise<any> {
         const origin = RequestBehavior.getAllowedOrigin(endpoint);
 
-        const client = new Rpc.RedirectRpcClient(endpoint, origin);
+        const client = new RedirectRpcClient(endpoint, origin);
         await client.init();
 
         const state: object = Object.assign({}, this._localState, { __command: command });
@@ -73,58 +73,16 @@ export class PopupRequestBehavior extends RequestBehavior {
         const origin = RequestBehavior.getAllowedOrigin(endpoint);
 
         const popup = this.createPopup(endpoint);
-        const client = new Rpc.PostMessageRpcClient(popup, origin);
+        const client = new PostMessageRpcClient(popup, origin);
         await client.init();
 
         try {
-            const result = await client.call(command, ...args);
-            client.close();
-            popup.close();
-            return result;
+            return await client.callAndPersist(command, ...args);
         } catch (e) {
-            client.close();
-            popup.close();
             throw e;
-        }
-    }
-
-    public createPopup(url: string) {
-        const popup = window.open(url, 'NimiqAccounts', this._options);
-        if (!popup) {
-            throw new Error('Failed to open popup');
-        }
-        return popup;
-    }
-}
-
-export class UrlEncodedPopupBehavior extends RequestBehavior {
-    private static DEFAULT_OPTIONS: string = '';
-    private _options: string;
-
-    constructor(options = UrlEncodedPopupBehavior.DEFAULT_OPTIONS) {
-        super(BehaviorType.POPUP);
-        this._options = options;
-    }
-
-    public async request(endpoint: string, command: RequestType, args: any[]): Promise<any> {
-        const origin = RequestBehavior.getAllowedOrigin(endpoint);
-
-        const id = Rpc.RandomUtils.generateRandomId();
-        const url = Rpc.UrlRpcEncoder.prepareRedirectInvocation(endpoint, id, '<postMessage>', command, args);
-
-        const popup = this.createPopup(url);
-        const client = new Rpc.ReceiveOnlyPostMessageRpcClient(popup, origin, id);
-        await client.init();
-
-        try {
-            const result = await client.listenFor(command);
+        } finally {
             client.close();
             popup.close();
-            return result;
-        } catch (e) {
-            client.close();
-            popup.close();
-            throw e;
         }
     }
 
@@ -141,7 +99,7 @@ export class IFrameRequestBehavior extends RequestBehavior {
     private static IFRAME_PATH_SUFFIX = '/iframe.html';
 
     private _iframe: HTMLIFrameElement | null;
-    private _client: Rpc.PostMessageRpcClient | null;
+    private _client: PostMessageRpcClient | null;
 
     constructor() {
         super(BehaviorType.IFRAME);
@@ -164,7 +122,7 @@ export class IFrameRequestBehavior extends RequestBehavior {
         }
 
         if (!this._client) {
-            this._client = new Rpc.PostMessageRpcClient(this._iframe.contentWindow, origin);
+            this._client = new PostMessageRpcClient(this._iframe.contentWindow, origin);
             await this._client.init();
         }
 

--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,7 @@
   "license": "Apache-2.0",
   "private": false,
   "dependencies": {
-    "@nimiq/rpc": "^0.1.0-beta.6"
+    "@nimiq/rpc": "^0.1.1"
   },
   "devDependencies": {
     "rollup": "^0.66.1",

--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,7 @@
   "license": "Apache-2.0",
   "private": false,
   "dependencies": {
-    "@nimiq/rpc": "^0.0.11"
+    "@nimiq/rpc": "^0.1.0-beta.3"
   },
   "devDependencies": {
     "rollup": "^0.66.1",

--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,7 @@
   "license": "Apache-2.0",
   "private": false,
   "dependencies": {
-    "@nimiq/rpc": "^0.1.0-beta.3"
+    "@nimiq/rpc": "^0.1.0-beta.5"
   },
   "devDependencies": {
     "rollup": "^0.66.1",

--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,7 @@
   "license": "Apache-2.0",
   "private": false,
   "dependencies": {
-    "@nimiq/rpc": "^0.1.0-beta.5"
+    "@nimiq/rpc": "^0.1.0-beta.6"
   },
   "devDependencies": {
     "rollup": "^0.66.1",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -18,10 +18,10 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@nimiq/rpc@^0.1.0-beta.3":
-  version "0.1.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.1.0-beta.3.tgz#7af632bc76e6a2d8d045bb5e25ca948f657651ab"
-  integrity sha512-jcZy8EmYbbfViXJNXxX2BxZplJx1NXqNoOPZTWVBzg6QU9sN/y4iR6d+yDs6WEplMONh10VyDb2FVVTowYPKXA==
+"@nimiq/rpc@^0.1.0-beta.5":
+  version "0.1.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.1.0-beta.5.tgz#a116c2ca7350dc3d01d7897bd6ead2ceb023f063"
+  integrity sha512-ortBLEVkAhouZBilom39bSSC1ZVQkpVSP6tsJHBtSB0QNjq0qCdjyDv+uefFEJ4o3XBBCIY4onjaj68HPvUltQ==
 
 "@types/estree@0.0.39":
   version "0.0.39"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -18,10 +18,10 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@nimiq/rpc@^0.1.0-beta.5":
-  version "0.1.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.1.0-beta.5.tgz#a116c2ca7350dc3d01d7897bd6ead2ceb023f063"
-  integrity sha512-ortBLEVkAhouZBilom39bSSC1ZVQkpVSP6tsJHBtSB0QNjq0qCdjyDv+uefFEJ4o3XBBCIY4onjaj68HPvUltQ==
+"@nimiq/rpc@^0.1.0-beta.6":
+  version "0.1.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.1.0-beta.6.tgz#aeec8c55548fd2166a33f97b5838cb51a8caeb6d"
+  integrity sha512-69BCfjlaJEuY9AF9NKDjgUVrHs8gPEV4h9Tq7LkYLEPpvZVcOd1fmXeWSsvECqpjtGYtWGXcAjZ3QMQy9wy8lQ==
 
 "@types/estree@0.0.39":
   version "0.0.39"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -18,10 +18,10 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@nimiq/rpc@^0.0.11":
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.0.11.tgz#7230365640663827fb115e0d6456222de3b1c5e3"
-  integrity sha512-aSTQwsTeSH46ubRDHqB7x82Alq5a9PlMYJUgDVd/4ET1dMTLm+4sjaFiWho3+SjG2n5/v09XKlDUBFDaENYT6w==
+"@nimiq/rpc@^0.1.0-beta.3":
+  version "0.1.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.1.0-beta.3.tgz#7af632bc76e6a2d8d045bb5e25ca948f657651ab"
+  integrity sha512-jcZy8EmYbbfViXJNXxX2BxZplJx1NXqNoOPZTWVBzg6QU9sN/y4iR6d+yDs6WEplMONh10VyDb2FVVTowYPKXA==
 
 "@types/estree@0.0.39":
   version "0.0.39"

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
         "postinstall": "cd client && yarn"
     },
     "dependencies": {
-        "@nimiq/keyguard-client": "^0.1.5",
+        "@nimiq/keyguard-client": "^0.1.6-beta.3",
         "@nimiq/network-client": "^0.1.0",
-        "@nimiq/rpc": "^0.1.0-beta.4",
+        "@nimiq/rpc": "^0.1.0-beta.6",
         "@nimiq/style": "^0.3.4",
         "@nimiq/utils": "^0.1.0",
         "@nimiq/vue-components": "https://github.com/nimiq/vue-components.git#build/accounts",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dependencies": {
         "@nimiq/keyguard-client": "^0.1.6-beta.4",
         "@nimiq/network-client": "^0.1.0",
-        "@nimiq/rpc": "^0.1.0-beta.6",
+        "@nimiq/rpc": "^0.1.1",
         "@nimiq/style": "^0.3.4",
         "@nimiq/utils": "^0.1.0",
         "@nimiq/vue-components": "https://github.com/nimiq/vue-components.git#build/accounts",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "postinstall": "cd client && yarn"
     },
     "dependencies": {
-        "@nimiq/keyguard-client": "^0.1.6-beta.3",
+        "@nimiq/keyguard-client": "^0.1.6-beta.4",
         "@nimiq/network-client": "^0.1.0",
         "@nimiq/rpc": "^0.1.0-beta.6",
         "@nimiq/style": "^0.3.4",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
         "postinstall": "cd client && yarn"
     },
     "dependencies": {
-        "@nimiq/keyguard-client": "^0.1.2",
+        "@nimiq/keyguard-client": "^0.1.5",
         "@nimiq/network-client": "^0.1.0",
-        "@nimiq/rpc": "^0.0.11",
+        "@nimiq/rpc": "^0.1.0-beta.4",
         "@nimiq/style": "^0.3.4",
         "@nimiq/utils": "^0.1.0",
         "@nimiq/vue-components": "https://github.com/nimiq/vue-components.git#build/accounts",

--- a/src/App.vue
+++ b/src/App.vue
@@ -29,8 +29,9 @@ export default class App extends Vue {
 
     private isRequestLoaded = false;
 
-    public created() {
-        this.$store.dispatch('initWallets');
+    public async created() {
+        await this.$store.dispatch('initWallets');
+        this.$rpc.start();
     }
 
     public mounted() {

--- a/src/components/CheckoutDetails.vue
+++ b/src/components/CheckoutDetails.vue
@@ -49,7 +49,7 @@ export default class CheckoutDetails extends Vue {
 
     @Emit()
     private changeAccount() {
-        this.$router.push({name: `${RequestType.CHECKOUT}-change-account`});
+        this.$rpc.routerPush(`${RequestType.CHECKOUT}-change-account`);
     }
 }
 </script>

--- a/src/components/Network.vue
+++ b/src/components/Network.vue
@@ -59,7 +59,6 @@ class Network extends Vue {
                     new Nimiq.PublicKey(keyguardResult.publicKey),
                     new Nimiq.Signature(keyguardResult.signature),
                 ).serialize(),
-                keyguardRequest.networkId,
             );
         } else {
             tx = new Nimiq.BasicTransaction(
@@ -69,7 +68,6 @@ class Network extends Vue {
                 keyguardRequest.fee,
                 keyguardRequest.validityStartHeight,
                 new Nimiq.Signature(keyguardResult.signature),
-                keyguardRequest.networkId,
             );
         }
 

--- a/src/lib/RpcApi.ts
+++ b/src/lib/RpcApi.ts
@@ -23,7 +23,7 @@ export default class RpcApi {
         this._staticStore = staticStore;
         this._router = router;
         this._server = new RpcServer('*');
-        this._keyguardClient = new KeyguardClient();
+        this._keyguardClient = new KeyguardClient( undefined, undefined, undefined, true);
 
         this._registerAccountsApis([
             RequestType.SIGN_TRANSACTION,

--- a/src/lib/RpcApi.ts
+++ b/src/lib/RpcApi.ts
@@ -99,7 +99,7 @@ export default class RpcApi {
 
             // Recreate original URL with original query parameters
             const rpcState = this._staticStore.rpcState!;
-            const redirectUrl = rpcState.toRequestUrl().replace(/\+/g, ' ');
+            const redirectUrl = rpcState.toRequestUrl();
 
             const query = this._parseUrlParams(redirectUrl);
             this._router.push({ name: this._staticStore.originalRouteName, query });
@@ -138,7 +138,7 @@ export default class RpcApi {
     private _parseUrlParams(query: string) {
         const params: {[key: string]: string} = {};
         if (!query) return params;
-        const keyValues = query.substr(1).split('&')
+        const keyValues = query.substr(1).replace(/\+/g, ' ').split('&')
             .map((keyValueString) => keyValueString.split('='));
 
         for (const keyValue of keyValues) {

--- a/src/lib/RpcApi.ts
+++ b/src/lib/RpcApi.ts
@@ -23,7 +23,7 @@ export default class RpcApi {
         this._staticStore = staticStore;
         this._router = router;
         this._server = new RpcServer('*');
-        this._keyguardClient = new KeyguardClient( undefined, undefined, undefined, true);
+        this._keyguardClient = new KeyguardClient();
 
         this._registerAccountsApis([
             RequestType.SIGN_TRANSACTION,

--- a/src/lib/RpcApi.ts
+++ b/src/lib/RpcApi.ts
@@ -1,4 +1,4 @@
-import { RpcServer, State as RpcState, ResponseStatus } from '@nimiq/rpc';
+import { RpcServer, State as RpcState, ResponseStatus, UrlRpcEncoder } from '@nimiq/rpc';
 import { BrowserDetection } from '@nimiq/utils';
 import { RootState } from '@/store';
 import { Store } from 'vuex';
@@ -61,6 +61,11 @@ export default class RpcApi {
         return client;
     }
 
+    public routerPush(routeName: string) {
+        const query = this._parseUrlParams(window.location.search);
+        this._router.push({name: routeName, query});
+    }
+
     public routerReplace(routeName: string) {
         const query = this._parseUrlParams(window.location.search);
         this._router.replace({name: routeName, query});
@@ -91,7 +96,19 @@ export default class RpcApi {
         // Check for originalRouteName in StaticStore and route there
         if (this._staticStore.originalRouteName && (!(result instanceof Error) || result.message !== 'CANCELED')) {
             this._staticStore.sideResult = result;
-            this._router.push({ name: this._staticStore.originalRouteName });
+
+            // Recreate original URL with original query parameters
+            const rpcState = this._staticStore.rpcState!;
+            const redirectUrl = UrlRpcEncoder.prepareRedirectInvocation(
+                '',
+                rpcState.data.id,
+                this._staticStore.rpcState!.returnURL || '<postMessage>',
+                rpcState.data.command,
+                rpcState.data.args,
+            ).replace(/\+/g, ' ');
+
+            const query = this._parseUrlParams(redirectUrl);
+            this._router.push({ name: this._staticStore.originalRouteName, query });
             delete this._staticStore.originalRouteName;
             return;
         }

--- a/src/lib/RpcApi.ts
+++ b/src/lib/RpcApi.ts
@@ -1,4 +1,4 @@
-import { RpcServer, State as RpcState, ResponseStatus, UrlRpcEncoder } from '@nimiq/rpc';
+import { RpcServer, State as RpcState, ResponseStatus } from '@nimiq/rpc';
 import { BrowserDetection } from '@nimiq/utils';
 import { RootState } from '@/store';
 import { Store } from 'vuex';
@@ -99,13 +99,7 @@ export default class RpcApi {
 
             // Recreate original URL with original query parameters
             const rpcState = this._staticStore.rpcState!;
-            const redirectUrl = UrlRpcEncoder.prepareRedirectInvocation(
-                '',
-                rpcState.data.id,
-                this._staticStore.rpcState!.returnURL || '<postMessage>',
-                rpcState.data.command,
-                rpcState.data.args,
-            ).replace(/\+/g, ' ');
+            const redirectUrl = rpcState.toRequestUrl().replace(/\+/g, ' ');
 
             const query = this._parseUrlParams(redirectUrl);
             this._router.push({ name: this._staticStore.originalRouteName, query });
@@ -136,7 +130,6 @@ export default class RpcApi {
                     hasRpcState: !!this._staticStore.rpcState,
                     hasRequest: !!this._staticStore.request,
                 });
-
                 this.routerReplace(request);
             });
         }
@@ -149,7 +142,7 @@ export default class RpcApi {
             .map((keyValueString) => keyValueString.split('='));
 
         for (const keyValue of keyValues) {
-            // @ts-ignore
+            // @ts-ignore Property 'decodeURIComponent' does not exist on type 'Window'
             params[keyValue[0]] = window.decodeURIComponent(keyValue[1]);
         }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ self.NIMIQ_IQONS_SVG_PATH = '/img/iqons.min.cc877caa.svg';
 
 const rpcApi = new RpcApi(store, staticStore, router);
 Vue.prototype.$rpc = rpcApi;
+// rpcApi ist started in App.vue->created()
 
 if (window.location.origin === 'https://accounts.nimiq-testnet.com') {
   Vue.use(VueRaven, {
@@ -27,9 +28,6 @@ new Vue({
   store,
   render: (h) => h(App),
 }).$mount('#app');
-
-// Start RPC Api
-rpcApi.start();
 
 // Types
 declare module 'vue/types/vue' {

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,8 +14,7 @@ Vue.config.productionTip = false;
 self.NIMIQ_IQONS_SVG_PATH = '/img/iqons.min.cc877caa.svg';
 
 const rpcApi = new RpcApi(store, staticStore, router);
-Vue.prototype.$rpc = rpcApi;
-// rpcApi ist started in App.vue->created()
+Vue.prototype.$rpc = rpcApi; // rpcApi is started in App.vue->created()
 
 if (window.location.origin === 'https://accounts.nimiq-testnet.com') {
   Vue.use(VueRaven, {

--- a/src/store.ts
+++ b/src/store.ts
@@ -54,7 +54,7 @@ const store: StoreOptions<RootState> = {
     actions: {
         initWallets({ state, commit }) {
             // Fetch data from store
-            WalletStore.Instance.list().then((walletInfoEntries) => {
+            return WalletStore.Instance.list().then((walletInfoEntries) => {
                 const wallets = walletInfoEntries.map((walletInfoEntry) => WalletInfo.fromObject(walletInfoEntry));
                 commit('initWallets', wallets);
 
@@ -92,7 +92,6 @@ const store: StoreOptions<RootState> = {
                     userFriendlyAddress: activeUserFriendlyAddress,
                 });
             });
-
         },
     },
     getters: {

--- a/src/views/CheckoutErrorHandler.vue
+++ b/src/views/CheckoutErrorHandler.vue
@@ -11,7 +11,7 @@ export default class CheckoutErrorHandler extends ErrorHandler {
         if (this.keyguardResult instanceof Error
             && this.keyguardResult.message === 'Request aborted') {
             // this Error should be more specific. history.back does not work incredibly well
-            this.$router.push({name: RequestType.CHECKOUT});
+            this.$rpc.routerReplace(RequestType.CHECKOUT);
             return true;
         }
         return false;

--- a/src/views/CheckoutOverview.vue
+++ b/src/views/CheckoutOverview.vue
@@ -57,7 +57,8 @@ export default class CheckoutOverview extends Vue {
         const request: KSignTransactionRequest = {
             layout: 'checkout',
             shopOrigin: this.rpcState.origin,
-            // shopLogoUrl: this.request.shopLogoUrl,
+            // @ts-ignore 'shopLogoUrl' does not exist in type 'SignTransactionRequest'
+            shopLogoUrl: this.request.shopLogoUrl,
             appName: this.request.appName,
 
             keyId: wallet.id,

--- a/src/views/CheckoutOverview.vue
+++ b/src/views/CheckoutOverview.vue
@@ -57,7 +57,7 @@ export default class CheckoutOverview extends Vue {
         const request: KSignTransactionRequest = {
             layout: 'checkout',
             shopOrigin: this.rpcState.origin,
-            shopLogoUrl: this.request.shopLogoUrl,
+            // shopLogoUrl: this.request.shopLogoUrl,
             appName: this.request.appName,
 
             keyId: wallet.id,
@@ -75,7 +75,6 @@ export default class CheckoutOverview extends Vue {
             validityStartHeight,
             data: this.request.data,
             flags: this.request.flags,
-            networkId: this.request.networkId,
         };
 
         const storedRequest = Object.assign({}, request, {

--- a/src/views/LoginErrorHandler.vue
+++ b/src/views/LoginErrorHandler.vue
@@ -11,7 +11,7 @@ export default class LoginErrorHandler extends ErrorHandler {
     protected requestSpecificErrors(): boolean {
         if (this.keyguardResult instanceof Error
             && this.keyguardResult.message === Errors.Messages.GOTO_CREATE) {
-            this.$router.push({name: RequestType.SIGNUP});
+            this.$rpc.routerReplace(RequestType.SIGNUP);
             return true;
         }
         return false;

--- a/src/views/SignMessage.vue
+++ b/src/views/SignMessage.vue
@@ -84,7 +84,7 @@ export default class SignMessage extends Vue {
 
         if (!accountInfo) {
             // Display interface for the user to select signer account
-            this.$router.push({name: `${RequestType.SIGN_MESSAGE}-overview`});
+            this.$rpc.routerPush(`${RequestType.SIGN_MESSAGE}-overview`);
             return;
         }
 

--- a/src/views/SignMessageErrorHandler.vue
+++ b/src/views/SignMessageErrorHandler.vue
@@ -16,7 +16,7 @@ export default class SignMessageErrorHandler extends ErrorHandler {
                 // This was a hand-through request, let it be a hand-through result
                 return false;
             }
-            this.$router.push({name: `${RequestType.SIGN_MESSAGE}-overview`});
+            this.$rpc.routerReplace(`${RequestType.SIGN_MESSAGE}-overview`);
             return true;
         }
         return false;

--- a/src/views/SignMessageOverview.vue
+++ b/src/views/SignMessageOverview.vue
@@ -45,7 +45,7 @@ export default class SignMessageOverview extends SignMessage {
 
     @Emit()
     private changeAccount() {
-        this.$router.push({name: `${RequestType.SIGN_MESSAGE}-change-account`});
+        this.$rpc.routerPush(`${RequestType.SIGN_MESSAGE}-change-account`);
     }
 
     @Emit()

--- a/src/views/SignTransaction.vue
+++ b/src/views/SignTransaction.vue
@@ -43,7 +43,6 @@ export default class SignTransaction extends Vue {
             validityStartHeight: this.request.validityStartHeight,
             data: this.request.data,
             flags: this.request.flags,
-            networkId: this.request.networkId,
         };
 
         const storedRequest = Object.assign({}, request, {

--- a/src/views/SignupErrorHandler.vue
+++ b/src/views/SignupErrorHandler.vue
@@ -10,7 +10,7 @@ export default class SignupErrorHandler extends ErrorHandler {
     protected requestSpecificErrors(): boolean {
         if (this.keyguardResult instanceof Error
             && this.keyguardResult.message === 'Request aborted') {
-            this.$router.push({name: RequestType.SIGNUP});
+            this.$rpc.routerReplace(RequestType.SIGNUP);
             return true;
         }
         return false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -627,10 +627,10 @@
     levelup "^2.0.2"
     node-lmdb "0.6.0"
 
-"@nimiq/keyguard-client@^0.1.6-beta.3":
-  version "0.1.6-beta.3"
-  resolved "https://registry.yarnpkg.com/@nimiq/keyguard-client/-/keyguard-client-0.1.6-beta.3.tgz#d38844d6a3cf712fcd7bbb92352f074e76a46c08"
-  integrity sha512-Cs+LaWJ0sEvKlXqQXF3GzlulaXpPyjiVX5iNEXqyWmMeRTDRlIfURqQ7AV6ALQGy4AugUPAzyKWls8HjKKT3MA==
+"@nimiq/keyguard-client@^0.1.6-beta.4":
+  version "0.1.6-beta.4"
+  resolved "https://registry.yarnpkg.com/@nimiq/keyguard-client/-/keyguard-client-0.1.6-beta.4.tgz#b11c19d019d54e10632b0286765b5ddafe2f2815"
+  integrity sha512-CRnVBpSzOrWXTBGHuidQl6XlpCDd/ryBvtUsRTnDvsQe1FUBtHCUMkqg6K+CIjflkvYn99fprQWBWagaOelMEg==
   dependencies:
     "@nimiq/rpc" "^0.1.0-beta.6"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -627,12 +627,12 @@
     levelup "^2.0.2"
     node-lmdb "0.6.0"
 
-"@nimiq/keyguard-client@^0.1.5":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@nimiq/keyguard-client/-/keyguard-client-0.1.5.tgz#cb7e983bee19bb295b49daed87278d9f20c96168"
-  integrity sha512-Sz4D+yyvCUd8A0O34zvyzagN4NTa7GwLLcOo35KJFav4MeqaTo0PJ4S7r/8E7nq7qSChISocesL9nuaCWsrB9A==
+"@nimiq/keyguard-client@^0.1.6-beta.3":
+  version "0.1.6-beta.3"
+  resolved "https://registry.yarnpkg.com/@nimiq/keyguard-client/-/keyguard-client-0.1.6-beta.3.tgz#d38844d6a3cf712fcd7bbb92352f074e76a46c08"
+  integrity sha512-Cs+LaWJ0sEvKlXqQXF3GzlulaXpPyjiVX5iNEXqyWmMeRTDRlIfURqQ7AV6ALQGy4AugUPAzyKWls8HjKKT3MA==
   dependencies:
-    "@nimiq/rpc" "^0.1.0-beta.3"
+    "@nimiq/rpc" "^0.1.0-beta.6"
 
 "@nimiq/ledgerjs@https://github.com/nimiq/ledger-api.git":
   version "0.0.0"
@@ -655,15 +655,10 @@
   version "0.0.11"
   resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.0.11.tgz#7230365640663827fb115e0d6456222de3b1c5e3"
 
-"@nimiq/rpc@^0.1.0-beta.3":
-  version "0.1.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.1.0-beta.3.tgz#7af632bc76e6a2d8d045bb5e25ca948f657651ab"
-  integrity sha512-jcZy8EmYbbfViXJNXxX2BxZplJx1NXqNoOPZTWVBzg6QU9sN/y4iR6d+yDs6WEplMONh10VyDb2FVVTowYPKXA==
-
-"@nimiq/rpc@^0.1.0-beta.4":
-  version "0.1.0-beta.4"
-  resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.1.0-beta.4.tgz#e05c9abb13f2f44b6056903fe9754e6cb9e2fb8f"
-  integrity sha512-mp511v+htlo9yVB1PcvDtECqFZ9evBNBgML6ATZk3ZV/J0+qdsZfs75cwSVve1PxCrt6sTbhhesl8yIPbDaz2g==
+"@nimiq/rpc@^0.1.0-beta.6":
+  version "0.1.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.1.0-beta.6.tgz#aeec8c55548fd2166a33f97b5838cb51a8caeb6d"
+  integrity sha512-69BCfjlaJEuY9AF9NKDjgUVrHs8gPEV4h9Tq7LkYLEPpvZVcOd1fmXeWSsvECqpjtGYtWGXcAjZ3QMQy9wy8lQ==
 
 "@nimiq/style@^0.3.4":
   version "0.3.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -627,12 +627,12 @@
     levelup "^2.0.2"
     node-lmdb "0.6.0"
 
-"@nimiq/keyguard-client@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@nimiq/keyguard-client/-/keyguard-client-0.1.2.tgz#95771e320e377b462378eea5a1bbcecaf7d2fc33"
-  integrity sha512-IacvWqFdmGFzBLZ+e9pmlG7zgIKLLGa7tZqB8XQ6Jp1zyuly8vkH6tIwgefgwFUKbHCHrKV8/M5qXLTsMOTdAg==
+"@nimiq/keyguard-client@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@nimiq/keyguard-client/-/keyguard-client-0.1.5.tgz#cb7e983bee19bb295b49daed87278d9f20c96168"
+  integrity sha512-Sz4D+yyvCUd8A0O34zvyzagN4NTa7GwLLcOo35KJFav4MeqaTo0PJ4S7r/8E7nq7qSChISocesL9nuaCWsrB9A==
   dependencies:
-    "@nimiq/rpc" "^0.0.10"
+    "@nimiq/rpc" "^0.1.0-beta.3"
 
 "@nimiq/ledgerjs@https://github.com/nimiq/ledger-api.git":
   version "0.0.0"
@@ -651,13 +651,19 @@
   dependencies:
     "@nimiq/rpc" "^0.0.11"
 
-"@nimiq/rpc@^0.0.10":
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.0.10.tgz#e8d9f7a31fcebe4080d086c8617c1b6115a9b728"
-
 "@nimiq/rpc@^0.0.11":
   version "0.0.11"
   resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.0.11.tgz#7230365640663827fb115e0d6456222de3b1c5e3"
+
+"@nimiq/rpc@^0.1.0-beta.3":
+  version "0.1.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.1.0-beta.3.tgz#7af632bc76e6a2d8d045bb5e25ca948f657651ab"
+  integrity sha512-jcZy8EmYbbfViXJNXxX2BxZplJx1NXqNoOPZTWVBzg6QU9sN/y4iR6d+yDs6WEplMONh10VyDb2FVVTowYPKXA==
+
+"@nimiq/rpc@^0.1.0-beta.4":
+  version "0.1.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.1.0-beta.4.tgz#e05c9abb13f2f44b6056903fe9754e6cb9e2fb8f"
+  integrity sha512-mp511v+htlo9yVB1PcvDtECqFZ9evBNBgML6ATZk3ZV/J0+qdsZfs75cwSVve1PxCrt6sTbhhesl8yIPbDaz2g==
 
 "@nimiq/style@^0.3.4":
   version "0.3.4"


### PR DESCRIPTION
With these changes, and the according changes in the @nimiq/rpc and @nimiq/keyguard-client libs (already included here as package dependencies), it becomes possible for the user to refresh the page at every step throughout a request flow, without loosing the request or getting stuck.