### PR TITLE
Adapt WalletType enum to new type standard

### DIFF
--- a/src/lib/CookieJar.ts
+++ b/src/lib/CookieJar.ts
@@ -56,7 +56,7 @@ class CookieJar {
                 const labelBytes = this.cutLabel(account.label);
 
                 // Combined account label length & wallet type
-                bytes.push(labelBytes.length << 2); // type is LEGACY = 0, thus 0b00 anyway;
+                bytes.push(labelBytes.length << 2 | wallet.type);
 
                 // Account label
                 if (labelBytes.length > 0) bytes.push.apply(bytes, Array.from(labelBytes));

--- a/src/lib/WalletInfo.ts
+++ b/src/lib/WalletInfo.ts
@@ -2,9 +2,9 @@ import { AccountInfo, AccountInfoEntry } from './AccountInfo';
 import { ContractInfo } from './ContractInfo';
 
 export enum WalletType {
-    LEGACY,
-    BIP39,
-    LEDGER,
+    LEGACY = 1,
+    BIP39 = 2,
+    LEDGER = 3,
 }
 
 export class WalletInfo {

--- a/src/views/LoginSuccess.vue
+++ b/src/views/LoginSuccess.vue
@@ -5,7 +5,7 @@
                 <PageHeader>Your wallet is ready</PageHeader>
 
                 <PageBody>
-                    <div class="wallet-label" v-if="walletInfo && keyguardResult.keyType !== 0 /* LEGACY */">
+                    <div class="wallet-label" v-if="walletInfo && keyguardResult.keyType !== 1 /* LEGACY */">
                         <div class="wallet-icon nq-icon" :class="walletIconClass"></div>
                         <LabelInput :value="walletInfo.label" @changed="onWalletLabelChange"/>
                     </div>

--- a/src/views/Rename.vue
+++ b/src/views/Rename.vue
@@ -3,7 +3,7 @@
         <SmallPage class="rename">
             <PageHeader>Rename your Wallet</PageHeader>
             <PageBody v-if="wallet">
-                <div class="wallet-label" v-if="wallet.type !== 0 /* LEGACY */">
+                <div class="wallet-label" v-if="wallet.type !== 1 /* LEGACY */">
                     <div class="wallet-icon nq-icon" :class="walletIconClass"></div>
                     <LabelInput :value="wallet.label" @changed="onWalletLabelChange" ref="wallet"/>
                 </div>

--- a/tests/unit/CookieJar.spec.ts
+++ b/tests/unit/CookieJar.spec.ts
@@ -275,7 +275,7 @@ const BYTES = [
     // wallet 1 (BIP39)
     30, 227, 217, 38, 164, 156, // wallet id
     1, // keyMissing = true
-    37, // wallet label length (9), wallet type (1)
+    38, // wallet label length (9), wallet type (2)
     77, 97, 105, 110, 32, 240, 159, 153, 137, // wallet label
     2, // number of accounts
 
@@ -291,7 +291,7 @@ const BYTES = [
     // wallet 2 (LEDGER)
     30, 227, 217, 38, 164, 157, // wallet id
     1, // keyMissing = true
-    2, // wallet label length (0), wallet type (2)
+    3, // wallet label length (0), wallet type (3)
     1, // number of accounts
 
         // account 1
@@ -302,7 +302,7 @@ const BYTES = [
     // wallet 3 (LEGACY)
     30, 227, 217, 38, 164, 158, // wallet id
     1, // keyMissing = true
-    40, // account label length (10), wallet type (0)
+    41, // account label length (10), wallet type (1)
 
         // account
         79, 108, 100, 65, 99, 99, 111, 117, 110, 116, // account label
@@ -311,7 +311,7 @@ const BYTES = [
     // wallet 4 (BIP39)
     30, 227, 217, 38, 164, 159, // wallet id
     0, // keyMissing = false
-    37, // wallet label length (9), wallet type (1)
+    38, // wallet label length (9), wallet type (2)
     77, 97, 105, 110, 32, 240, 159, 153, 137, // wallet label
     2, // number of accounts
 
@@ -327,7 +327,7 @@ const BYTES = [
     // wallet 2 (LEDGER)
     30, 227, 217, 38, 164, 160, // wallet id
     0, // keyMissing = false
-    2, // wallet label length (0), wallet type (2)
+    3, // wallet label length (0), wallet type (3)
     1, // number of accounts
 
         // account 1
@@ -338,7 +338,7 @@ const BYTES = [
     // wallet 3 (LEGACY)
     30, 227, 217, 38, 164, 161, // wallet id
     0, // keyMissing = false
-    40, // account label length (10), wallet type (0)
+    41, // account label length (10), wallet type (1)
 
         // account
         79, 108, 100, 65, 99, 99, 111, 117, 110, 116, // account label


### PR DESCRIPTION
https://github.com/nimiq/keyguard-next/pull/155 changed the type number for LEGACY and BIP39 types. This PR adapts them in the Accounts Manager.