### PR TITLE
Use custom KeyguardClient returnURL to remove need for result guards

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "postinstall": "cd client && yarn"
     },
     "dependencies": {
-        "@nimiq/keyguard-client": "^0.2.3",
+        "@nimiq/keyguard-client": "^0.2.4-beta.0",
         "@nimiq/ledgerjs": "https://github.com/nimiq/ledger-api.git",
         "@nimiq/network-client": "^0.1.5",
         "@nimiq/rpc": "^0.1.1",

--- a/src/lib/RpcApi.ts
+++ b/src/lib/RpcApi.ts
@@ -61,7 +61,7 @@ export default class RpcApi {
 
     public createKeyguardClient() {
         const localState = this._exportState();
-        const client = new KeyguardClient(Config.keyguardEndpoint, localState);
+        const client = new KeyguardClient(Config.keyguardEndpoint, window.location.origin, localState);
         return client;
     }
 

--- a/src/views/AddAccount.vue
+++ b/src/views/AddAccount.vue
@@ -7,17 +7,12 @@ import { DeriveAddressRequest } from '@nimiq/keyguard-client';
 import { Static } from '../lib/StaticStore';
 import { WalletStore } from '@/lib/WalletStore';
 import { WalletType } from '@/lib/WalletInfo';
-import { State } from 'vuex-class';
-import KeyguardClient from '@nimiq/keyguard-client';
 
 @Component
 export default class AddAccount extends Vue {
     @Static private request!: ParsedAddAccountRequest;
-    @State private keyguardResult?: KeyguardClient.DeriveAddressResult;
 
     public async created() {
-        if (this.keyguardResult) return;
-
         const wallet = await WalletStore.Instance.get(this.request.walletId);
         if (!wallet) {
             this.$rpc.reject(new Error('Wallet not found'));

--- a/src/views/ChangePassword.vue
+++ b/src/views/ChangePassword.vue
@@ -5,17 +5,13 @@ import { Component, Vue } from 'vue-property-decorator';
 import { ParsedChangePasswordRequest } from '../lib/RequestTypes';
 import { WalletStore } from '@/lib/WalletStore';
 import { Static } from '../lib/StaticStore';
-import { State } from 'vuex-class';
 import KeyguardClient from '@nimiq/keyguard-client';
 
 @Component
 export default class ChangePassword extends Vue {
     @Static private request!: ParsedChangePasswordRequest;
-    @State private keyguardResult?: KeyguardClient.SimpleResult;
 
     public async created() {
-        if (this.keyguardResult) return;
-
         const wallet = await WalletStore.Instance.get(this.request.walletId);
         if (!wallet) throw new Error('Wallet ID not found');
 

--- a/src/views/Export.vue
+++ b/src/views/Export.vue
@@ -4,18 +4,14 @@
 import { Component, Vue } from 'vue-property-decorator';
 import { ParsedExportRequest } from '../lib/RequestTypes';
 import { SimpleRequest } from '@nimiq/keyguard-client';
-import { State } from 'vuex-class';
 import { WalletStore } from '@/lib/WalletStore';
 import { Static } from '../lib/StaticStore';
-import KeyguardClient from '@nimiq/keyguard-client';
 
 @Component
 export default class Export extends Vue {
     @Static private request!: ParsedExportRequest;
-    @State private keyguardResult!: KeyguardClient.SimpleResult;
 
     public async created() {
-        if (this.keyguardResult) return;
         const wallet = await WalletStore.Instance.get(this.request.walletId);
         if (!wallet) throw new Error('Wallet ID not found');
 

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -5,17 +5,13 @@ import { Component, Vue } from 'vue-property-decorator';
 import { ParsedLoginRequest } from '../lib/RequestTypes';
 import { Static } from '../lib/StaticStore';
 import { DEFAULT_KEY_PATH } from '@/lib/Constants';
-import { State } from 'vuex-class';
 import KeyguardClient from '@nimiq/keyguard-client';
 
 @Component
 export default class Login extends Vue {
     @Static private request!: ParsedLoginRequest;
-    @State private keyguardResult?: KeyguardClient.KeyResult;
 
     public created() {
-        if (this.keyguardResult) return;
-
         const request: KeyguardClient.ImportRequest = {
             appName: this.request.appName,
             defaultKeyPath: DEFAULT_KEY_PATH,

--- a/src/views/Logout.vue
+++ b/src/views/Logout.vue
@@ -5,17 +5,13 @@ import { Component, Vue } from 'vue-property-decorator';
 import { ParsedLogoutRequest } from '../lib/RequestTypes';
 import { WalletStore } from '@/lib/WalletStore';
 import { Static } from '../lib/StaticStore';
-import { State } from 'vuex-class';
 import KeyguardClient from '@nimiq/keyguard-client';
 
 @Component
 export default class Logout extends Vue {
     @Static private request!: ParsedLogoutRequest;
-    @State private keyguardResult?: KeyguardClient.SimpleResult;
 
     public async created() {
-        if (this.keyguardResult) return;
-
         const wallet = await WalletStore.Instance.get(this.request.walletId);
         if (!wallet) throw new Error('Wallet ID not found');
 

--- a/src/views/SignMessage.vue
+++ b/src/views/SignMessage.vue
@@ -26,7 +26,7 @@
 
 <script lang="ts">
 import { Component, Emit, Vue } from 'vue-property-decorator';
-import { State, Getter, Mutation } from 'vuex-class';
+import { Getter, Mutation } from 'vuex-class';
 import { SmallPage, AccountSelector } from '@nimiq/vue-components';
 import { RequestType, ParsedSignMessageRequest, OnboardingResult } from '../lib/RequestTypes';
 import staticStore, { Static } from '../lib/StaticStore';
@@ -42,7 +42,6 @@ import { State as RpcState } from '@nimiq/rpc';
 export default class SignMessage extends Vue {
     @Static protected request!: ParsedSignMessageRequest;
     @Static private rpcState!: RpcState;
-    @State private keyguardResult!: KeyguardClient.SignMessageResult;
 
     @Getter private processedWallets!: WalletInfo[];
     @Getter private findWallet!: (id: string) => WalletInfo | undefined;
@@ -56,8 +55,6 @@ export default class SignMessage extends Vue {
     private showAccountSelector = false;
 
     private async created() {
-        if (this.keyguardResult) return;
-
         await this.handleOnboardingResult();
 
         if (this.request.walletId && this.request.signer) {

--- a/src/views/SignTransaction.vue
+++ b/src/views/SignTransaction.vue
@@ -6,16 +6,12 @@ import { ParsedSignTransactionRequest } from '../lib/RequestTypes';
 import KeyguardClient from '@nimiq/keyguard-client';
 import { WalletStore } from '@/lib/WalletStore';
 import staticStore, { Static } from '../lib/StaticStore';
-import { State } from 'vuex-class';
 
 @Component
 export default class SignTransaction extends Vue {
     @Static private request!: ParsedSignTransactionRequest;
-    @State private keyguardResult?: KeyguardClient.SignTransactionResult;
 
     public async created() {
-        if (this.keyguardResult) return;
-
         // Forward user through AccountsManager to Keyguard
         const wallet = await WalletStore.Instance.get(this.request.walletId);
         if (!wallet) throw new Error('Wallet ID not found');

--- a/src/views/Signup.vue
+++ b/src/views/Signup.vue
@@ -5,17 +5,13 @@ import { Component, Vue } from 'vue-property-decorator';
 import { ParsedSignupRequest } from '../lib/RequestTypes';
 import { Static } from '../lib/StaticStore';
 import { DEFAULT_KEY_PATH } from '@/lib/Constants';
-import { State } from 'vuex-class';
 import KeyguardClient from '@nimiq/keyguard-client';
 
 @Component
 export default class Signup extends Vue {
     @Static private request!: ParsedSignupRequest;
-    @State private keyguardResult?: KeyguardClient.KeyResult[];
 
     public created() {
-        if (this.keyguardResult) return;
-
         const request: KeyguardClient.CreateRequest = {
             appName: this.request.appName,
             defaultKeyPath: DEFAULT_KEY_PATH,

--- a/yarn.lock
+++ b/yarn.lock
@@ -720,10 +720,10 @@
     levelup "^2.0.2"
     node-lmdb "0.6.0"
 
-"@nimiq/keyguard-client@^0.2.3":
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/@nimiq/keyguard-client/-/keyguard-client-0.2.3.tgz#c7046a019d6d911c5aed60fdcc08a3c2b5b97939"
-  integrity sha512-QeSY1px/3X5yAY32GT/n2TP5HixdDWcdltUV1XtJybvecoWx+YGh3EujxqCoLbTgr0TZxOMKxY6Ds8W0n8Z5kw==
+"@nimiq/keyguard-client@^0.2.4-beta.0":
+  version "0.2.4-beta.0"
+  resolved "https://registry.yarnpkg.com/@nimiq/keyguard-client/-/keyguard-client-0.2.4-beta.0.tgz#29ff5fed2e92e6e0575423d45ad3095e62fdd8c1"
+  integrity sha512-FIzv+qEpzwiN92sQ74DdQIa6SfsPm+aIoU8UUUesA+vgMHZrpE8QcxwKFNtSLqK6zjg5hxf+zAAgDaxB0DUG8w==
   dependencies:
     "@nimiq/rpc" "^0.1.1"
 


### PR DESCRIPTION
By telling the KeyguardClient to return to the root and not to a path, the VuexRouter is not invoked and the path's component is not loaded, resulting in no `created()` or `mounted()` handlers firing and redirecting back to the Keyguard.

Requires https://github.com/nimiq/keyguard-next/pull/242.