### PR TITLE
Use Iqons names for address labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "postinstall": "cd client && yarn"
     },
     "dependencies": {
+        "@nimiq/iqons": "^1.3.0",
         "@nimiq/keyguard-client": "^0.2.8",
         "@nimiq/ledgerjs": "https://github.com/nimiq/ledger-api.git",
         "@nimiq/network-client": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "postinstall": "cd client && yarn"
     },
     "dependencies": {
-        "@nimiq/iqons": "^1.3.0",
+        "@nimiq/iqons": "^1.4.0",
         "@nimiq/keyguard-client": "^0.2.8",
         "@nimiq/ledgerjs": "https://github.com/nimiq/ledger-api.git",
         "@nimiq/network-client": "^0.1.5",

--- a/src/lib/Constants.ts
+++ b/src/lib/Constants.ts
@@ -3,8 +3,6 @@
  */
 
 // Addresses
-export const ADDRESS_DEFAULT_LABEL_KEYGUARD = 'Standard Address';
-export const ADDRESS_DEFAULT_LABEL_LEDGER = 'Ledger Address';
 export const DEFAULT_KEY_PATH = `m/44'/242'/0'/0'`;
 
 // Transactions

--- a/src/lib/Constants.ts
+++ b/src/lib/Constants.ts
@@ -14,9 +14,9 @@ export const LABEL_MAX_LENGTH = 63; // in bytes
 
 // Accounts
 export const ACCOUNT_BIP32_BASE_PATH_KEYGUARD = `m/44'/242'/0'/`;
-export const ACCOUNT_DEFAULT_LABEL_KEYGUARD = 'Keyguard Account';
 export const ACCOUNT_DEFAULT_LABEL_LEDGER = 'Ledger Account';
 export const ACCOUNT_DEFAULT_LABEL_LEGACY = 'Legacy Account';
+export const ACCOUNT_TEMPORARY_LABEL_KEYGUARD = '~~TEMP~~';
 export const ACCOUNT_MAX_ALLOWED_ADDRESS_GAP = 20;
 
 // Compatibility

--- a/src/lib/CookieDecoder.ts
+++ b/src/lib/CookieDecoder.ts
@@ -104,11 +104,7 @@ export class CookieDecoder {
         // Wallet label
         const walletLabelBytes = this.readBytes(bytes, labelLength);
 
-        const walletLabel = walletLabelBytes.length === 0
-            ? type === WalletType.BIP39
-                ? 'unkown'
-                : ACCOUNT_DEFAULT_LABEL_LEDGER
-            : Utf8Tools.utf8ByteArrayToString(new Uint8Array(walletLabelBytes));
+        const walletLabel = Utf8Tools.utf8ByteArrayToString(new Uint8Array(walletLabelBytes));
 
         const accounts = this.decodeAccounts(bytes, type);
 
@@ -161,11 +157,7 @@ export class CookieDecoder {
         // Account label
         const labelBytes = this.readBytes(bytes, labelLength);
 
-        const accountLabel = labelBytes.length === 0
-            ? type === WalletType.BIP39
-                ? 'unkown'
-                : 'unkown'
-            : Utf8Tools.utf8ByteArrayToString(new Uint8Array(labelBytes));
+        const accountLabel = Utf8Tools.utf8ByteArrayToString(new Uint8Array(labelBytes));
 
         // Account address
         // (iframe does not have Nimiq lib)

--- a/src/lib/CookieDecoder.ts
+++ b/src/lib/CookieDecoder.ts
@@ -9,8 +9,6 @@ import {
     ACCOUNT_DEFAULT_LABEL_KEYGUARD,
     ACCOUNT_DEFAULT_LABEL_LEDGER,
     LABEL_MAX_LENGTH,
-    ADDRESS_DEFAULT_LABEL_KEYGUARD,
-    ADDRESS_DEFAULT_LABEL_LEDGER,
 } from '@/lib/Constants';
 
 export class CookieDecoder {
@@ -109,7 +107,7 @@ export class CookieDecoder {
 
         const walletLabel = walletLabelBytes.length === 0
             ? type === WalletType.BIP39
-                ? ACCOUNT_DEFAULT_LABEL_KEYGUARD
+                ? 'unkown'
                 : ACCOUNT_DEFAULT_LABEL_LEDGER
             : Utf8Tools.utf8ByteArrayToString(new Uint8Array(walletLabelBytes));
 
@@ -166,8 +164,8 @@ export class CookieDecoder {
 
         const accountLabel = labelBytes.length === 0
             ? type === WalletType.BIP39
-                ? ADDRESS_DEFAULT_LABEL_KEYGUARD
-                : ADDRESS_DEFAULT_LABEL_LEDGER
+                ? 'unkown'
+                : 'unkown'
             : Utf8Tools.utf8ByteArrayToString(new Uint8Array(labelBytes));
 
         // Account address

--- a/src/lib/CookieDecoder.ts
+++ b/src/lib/CookieDecoder.ts
@@ -6,7 +6,6 @@ import { AccountInfoEntry } from './AccountInfo';
 import CookieJar from './CookieJar';
 import {
     ACCOUNT_DEFAULT_LABEL_LEGACY,
-    ACCOUNT_DEFAULT_LABEL_KEYGUARD,
     ACCOUNT_DEFAULT_LABEL_LEDGER,
     LABEL_MAX_LENGTH,
 } from '@/lib/Constants';

--- a/src/lib/LabelingMachine.ts
+++ b/src/lib/LabelingMachine.ts
@@ -1,5 +1,5 @@
 // @ts-ignore Could not find a declaration file for module '@nimiq/iqons'.
-import { makeHash } from '@nimiq/iqons';
+import { getBackgroundColorName } from '@nimiq/iqons';
 // @ts-ignore Could not find a declaration file for module '@nimiq/iqons/dist/iqons-name.min.js'.
 import { name } from '@nimiq/iqons/dist/iqons-name.min.js';
 
@@ -9,24 +9,6 @@ export default class LabelingMachine {
     }
 
     public static labelAccount(firstAddress: string): string {
-        const colorNames = [
-            'Orange',
-            'Red',
-            'Yellow',
-            'Blue',
-            'Light-Blue',
-            'Purple',
-            'Green',
-            'Pink',
-            'Light-Green',
-            'Brown',
-        ];
-        const index = this.getBackgroundColorIndex(firstAddress);
-        return `${colorNames[index]} Account`;
-    }
-
-    private static getBackgroundColorIndex(address: string): number {
-        const hash = makeHash(address);
-        return parseInt(hash[2], 10);
+        return `${getBackgroundColorName(firstAddress)} Account`;
     }
 }

--- a/src/lib/LabelingMachine.ts
+++ b/src/lib/LabelingMachine.ts
@@ -1,0 +1,32 @@
+// @ts-ignore Could not find a declaration file for module '@nimiq/iqons'.
+import { makeHash } from '@nimiq/iqons';
+// @ts-ignore Could not find a declaration file for module '@nimiq/iqons/dist/iqons-name.min.js'.
+import { name } from '@nimiq/iqons/dist/iqons-name.min.js';
+
+export default class LabelingMachine {
+    public static labelAddress(address: string): string {
+        return name(address);
+    }
+
+    public static labelAccount(firstAddress: string): string {
+        const colorNames = [
+            'Orange',
+            'Red',
+            'Yellow',
+            'Blue',
+            'Light-Blue',
+            'Purple',
+            'Green',
+            'Pink',
+            'Light-Green',
+            'Brown',
+        ];
+        const index = this.getBackgroundColorIndex(firstAddress);
+        return `${colorNames[index]} Account`;
+    }
+
+    private static getBackgroundColorIndex(address: string): number {
+        const hash = makeHash(address);
+        return parseInt(hash[2], 10);
+    }
+}

--- a/src/lib/WalletInfoCollector.ts
+++ b/src/lib/WalletInfoCollector.ts
@@ -6,8 +6,8 @@ import { WalletInfo, WalletType } from '@/lib/WalletInfo';
 import LedgerApi from '@/lib/LedgerApi'; // TODO import LedgerApi only when needed
 import {
     ACCOUNT_DEFAULT_LABEL_LEGACY,
-    ACCOUNT_DEFAULT_LABEL_KEYGUARD,
     ACCOUNT_DEFAULT_LABEL_LEDGER,
+    ACCOUNT_TEMPORARY_LABEL_KEYGUARD,
     ACCOUNT_MAX_ALLOWED_ADDRESS_GAP,
     ACCOUNT_BIP32_BASE_PATH_KEYGUARD,
 } from '@/lib/Constants';
@@ -72,7 +72,7 @@ export default class WalletInfoCollector {
         }
 
         // Label Keyguard accounts according to their first identicon background color
-        if (walletType === WalletType.BIP39 && walletInfo.label === ACCOUNT_DEFAULT_LABEL_KEYGUARD) {
+        if (walletType === WalletType.BIP39 && walletInfo.label === ACCOUNT_TEMPORARY_LABEL_KEYGUARD) {
             walletInfo.label = LabelingMachine.labelAccount((await derivedAccountsPromise)[0].address);
         }
 
@@ -152,7 +152,7 @@ export default class WalletInfoCollector {
         const label = walletType === WalletType.LEGACY
             ? ACCOUNT_DEFAULT_LABEL_LEGACY
             : walletType === WalletType.BIP39
-                ? ACCOUNT_DEFAULT_LABEL_KEYGUARD
+                ? ACCOUNT_TEMPORARY_LABEL_KEYGUARD
                 : ACCOUNT_DEFAULT_LABEL_LEDGER;
         return new WalletInfo(
             walletId,

--- a/src/lib/WalletInfoCollector.ts
+++ b/src/lib/WalletInfoCollector.ts
@@ -8,12 +8,11 @@ import {
     ACCOUNT_DEFAULT_LABEL_LEGACY,
     ACCOUNT_DEFAULT_LABEL_KEYGUARD,
     ACCOUNT_DEFAULT_LABEL_LEDGER,
-    ADDRESS_DEFAULT_LABEL_KEYGUARD,
-    ADDRESS_DEFAULT_LABEL_LEDGER,
     ACCOUNT_MAX_ALLOWED_ADDRESS_GAP,
     ACCOUNT_BIP32_BASE_PATH_KEYGUARD,
 } from '@/lib/Constants';
 import Config from 'config';
+import LabelingMachine from './LabelingMachine';
 
 type BasicAccountInfo = { // tslint:disable-line:interface-over-type-literal
     address: string,
@@ -70,6 +69,11 @@ export default class WalletInfoCollector {
             // legacy wallets have no derived accounts
             await initialAccountsPromise;
             return walletInfo;
+        }
+
+        // Label Keyguard accounts according to their first identicon background color
+        if (walletType === WalletType.BIP39 && walletInfo.label === ACCOUNT_DEFAULT_LABEL_KEYGUARD) {
+            walletInfo.label = LabelingMachine.labelAccount((await derivedAccountsPromise)[0].address);
         }
 
         let foundAccounts: BasicAccountInfo[];
@@ -225,9 +229,7 @@ export default class WalletInfoCollector {
             const balance = balances ? balances.get(newAccount.address) : undefined;
             const accountInfo = existingAccountInfo || new AccountInfo(
                 newAccount.path,
-                walletInfo.type === WalletType.LEDGER
-                    ? ADDRESS_DEFAULT_LABEL_LEDGER
-                    : ADDRESS_DEFAULT_LABEL_KEYGUARD,
+                LabelingMachine.labelAddress(newAccount.address),
                 Nimiq.Address.fromUserFriendlyAddress(newAccount.address),
             );
             if (balance !== undefined) accountInfo.balance = balance;

--- a/src/views/SignupLedger.vue
+++ b/src/views/SignupLedger.vue
@@ -40,7 +40,7 @@ import WalletInfoCollector from '../lib/WalletInfoCollector';
 import { WalletInfo, WalletType } from '../lib/WalletInfo';
 import { AccountInfo } from '../lib/AccountInfo';
 import { WalletStore } from '../lib/WalletStore';
-import { ADDRESS_DEFAULT_LABEL_LEDGER } from '../lib/Constants';
+import LabelingMachine from '@/lib/LabelingMachine';
 
 @Component({components: {PageBody, SmallPage, LedgerUi, Loader, IdenticonSelector, WalletIdentifier}})
 export default class SignupLedger extends Vue {
@@ -153,7 +153,7 @@ export default class SignupLedger extends Vue {
             // an account already
             this.accountsToSelectFrom = currentlyCheckedAccounts.map((account) => new AccountInfo(
                 account.path,
-                ADDRESS_DEFAULT_LABEL_LEDGER,
+                LabelingMachine.labelAddress(account.address),
                 Nimiq.Address.fromUserFriendlyAddress(account.address),
                 0, // balance 0 because if user has to select an account, it's gonna be an unused one
             ));

--- a/src/views/SignupSuccess.vue
+++ b/src/views/SignupSuccess.vue
@@ -20,13 +20,8 @@ import { State } from 'vuex-class';
 import { WalletStore } from '@/lib/WalletStore';
 import { Account } from '../lib/PublicRequestTypes';
 import Loader from '@/components/Loader.vue';
-import {
-    ACCOUNT_DEFAULT_LABEL_KEYGUARD,
-    ACCOUNT_DEFAULT_LABEL_LEDGER,
-    ADDRESS_DEFAULT_LABEL_KEYGUARD,
-    ADDRESS_DEFAULT_LABEL_LEDGER,
-} from '@/lib/Constants';
 import KeyguardClient from '@nimiq/keyguard-client';
+import LabelingMachine from '@/lib/LabelingMachine';
 
 @Component({components: {SmallPage, Loader}})
 export default class SignupSuccess extends Vue {
@@ -37,10 +32,11 @@ export default class SignupSuccess extends Vue {
 
     private async mounted() {
         const walletType = WalletType.BIP39;
-        const walletLabel = ACCOUNT_DEFAULT_LABEL_KEYGUARD;
-        const accountLabel = ADDRESS_DEFAULT_LABEL_KEYGUARD;
 
         const createdAddress = new Nimiq.Address(this.keyguardResult[0].addresses[0].address);
+
+        const walletLabel = LabelingMachine.labelAccount(createdAddress.toUserFriendlyAddress());
+        const accountLabel = LabelingMachine.labelAddress(createdAddress.toUserFriendlyAddress());
 
         const accountInfo = new AccountInfo(
             this.keyguardResult[0].addresses[0].keyPath,

--- a/src/views/SignupSuccess.vue
+++ b/src/views/SignupSuccess.vue
@@ -35,8 +35,9 @@ export default class SignupSuccess extends Vue {
 
         const createdAddress = new Nimiq.Address(this.keyguardResult[0].addresses[0].address);
 
-        const walletLabel = LabelingMachine.labelAccount(createdAddress.toUserFriendlyAddress());
-        const accountLabel = LabelingMachine.labelAddress(createdAddress.toUserFriendlyAddress());
+        const userFriendlyAddress = createdAddress.toUserFriendlyAddress();
+        const walletLabel = LabelingMachine.labelAccount(userFriendlyAddress);
+        const accountLabel = LabelingMachine.labelAddress(userFriendlyAddress);
 
         const accountInfo = new AccountInfo(
             this.keyguardResult[0].addresses[0].keyPath,
@@ -47,7 +48,7 @@ export default class SignupSuccess extends Vue {
         const walletInfo = new WalletInfo(
             this.keyguardResult[0].keyId,
             walletLabel,
-            new Map<string, AccountInfo>().set(accountInfo.userFriendlyAddress, accountInfo),
+            new Map<string, AccountInfo>().set(userFriendlyAddress, accountInfo),
             [],
             walletType,
             false, // keyMissing
@@ -69,7 +70,7 @@ export default class SignupSuccess extends Vue {
             fileExported: walletInfo.fileExported,
             wordsExported: walletInfo.wordsExported,
             addresses: [{
-                address: accountInfo.userFriendlyAddress,
+                address: userFriendlyAddress,
                 label: accountInfo.label,
             }],
         };

--- a/tests/unit/CookieJar.spec.ts
+++ b/tests/unit/CookieJar.spec.ts
@@ -177,7 +177,7 @@ const OUT_DUMMY_WALLET_OBJECTS: WalletInfoEntry[] = [
                 DUMMY_ADDRESS_HR2,
                 {
                     path: 'not public',
-                    label: 'Standard Address',
+                    label: '',
                     address: DUMMY_ADDRESS_S2,
                 },
             ],
@@ -190,7 +190,7 @@ const OUT_DUMMY_WALLET_OBJECTS: WalletInfoEntry[] = [
     },
     {
         id: '1ee3d926a49d',
-        label: 'Ledger Account',
+        label: '',
         accounts: new Map<string, AccountInfoEntry>([
             [
                 BURN_ADDRESS_HR,
@@ -242,7 +242,7 @@ const OUT_DUMMY_WALLET_OBJECTS: WalletInfoEntry[] = [
                 DUMMY_ADDRESS_HR2,
                 {
                     path: 'not public',
-                    label: 'Standard Address',
+                    label: '',
                     address: DUMMY_ADDRESS_S2,
                 },
             ],
@@ -255,7 +255,7 @@ const OUT_DUMMY_WALLET_OBJECTS: WalletInfoEntry[] = [
     },
     {
         id: '1ee3d926a4a0',
-        label: 'Ledger Account',
+        label: '',
         accounts: new Map<string, AccountInfoEntry>([
             [
                 BURN_ADDRESS_HR,

--- a/yarn.lock
+++ b/yarn.lock
@@ -707,6 +707,13 @@
     nan "^2.10.0"
     ws "^5.2.0"
 
+"@nimiq/iqons@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@nimiq/iqons/-/iqons-1.3.0.tgz#7a570d082e72c70b7ce7f5da252c9f0109e28cc5"
+  integrity sha512-zyRM7wkMyE+oc3pVEfUAMETrjcPWiqQom+hI9oEBXWJmx/qgqU/RmNa8HbeLmL1DGIVevSw6dqDSlaPCJNgDRw==
+  dependencies:
+    dom-parser "^0.1.5"
+
 "@nimiq/jungle-db@^0.9.17":
   version "0.9.17"
   resolved "https://registry.yarnpkg.com/@nimiq/jungle-db/-/jungle-db-0.9.17.tgz#3a8a55f600da8f8b103ad988d177b2785e1bd6cc"
@@ -3045,6 +3052,11 @@ dom-event-types@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/dom-event-types/-/dom-event-types-1.0.0.tgz#5830a0a29e1bf837fe50a70cd80a597232813cae"
   integrity sha512-2G2Vwi2zXTHBGqXHsJ4+ak/iP0N8Ar+G8a7LiD2oup5o4sQWytwqqrZu/O6hIMV0KMID2PL69OhpshLO0n7UJQ==
+
+dom-parser@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/dom-parser/-/dom-parser-0.1.5.tgz#a4f6019f9a315b75d7428aaa7ccbf5bd859e16fb"
+  integrity sha1-pPYBn5oxW3XXQoqqfMv1vYWeFvs=
 
 dom-serializer@0:
   version "0.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -707,10 +707,10 @@
     nan "^2.10.0"
     ws "^5.2.0"
 
-"@nimiq/iqons@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@nimiq/iqons/-/iqons-1.3.0.tgz#7a570d082e72c70b7ce7f5da252c9f0109e28cc5"
-  integrity sha512-zyRM7wkMyE+oc3pVEfUAMETrjcPWiqQom+hI9oEBXWJmx/qgqU/RmNa8HbeLmL1DGIVevSw6dqDSlaPCJNgDRw==
+"@nimiq/iqons@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@nimiq/iqons/-/iqons-1.4.0.tgz#b20032734e8f3dd6f0f21a044d198320d2aa6dbc"
+  integrity sha512-pfxaaTYkuCUWrrUmJzpxU3gB2TXyX7gEnWHUrFJH8vsYoRUxa6jol91XSgOTnE51Aki5jd1KbHLYGiapvrkHPQ==
   dependencies:
     dom-parser "^0.1.5"
 


### PR DESCRIPTION
Uses the new `iqons-name` lib to generate automatic labels for addresses.

Also generates color-named labels for Keyguard accounts.

Only problem is, that the cookie does not encode the user-friendly address, and the iframe also does not have the Nimiq lib available, so there is no way to generate the default label, in case no label is stored in the cookie. It was originally planned to omit the label in the cookie, when it is the default label, to save cookie space, but this is currently not implemented anyways during cookie-writing. So the question is, should we remove the check for a label being omitted in the cookie?