### PR TITLE
Reject request when account not found

### DIFF
--- a/src/views/ChangePassword.vue
+++ b/src/views/ChangePassword.vue
@@ -13,7 +13,10 @@ export default class ChangePassword extends Vue {
 
     public async created() {
         const wallet = await WalletStore.Instance.get(this.request.walletId);
-        if (!wallet) throw new Error('Account ID not found');
+        if (!wallet) {
+            this.$rpc.reject(new Error('Account ID not found'));
+            return;
+        }
 
         const request: KeyguardClient.SimpleRequest = {
             appName: this.request.appName,

--- a/src/views/Export.vue
+++ b/src/views/Export.vue
@@ -13,7 +13,10 @@ export default class Export extends Vue {
 
     public async created() {
         const wallet = await WalletStore.Instance.get(this.request.walletId);
-        if (!wallet) throw new Error('Account ID not found');
+        if (!wallet) {
+            this.$rpc.reject(new Error('Account ID not found'));
+            return;
+        }
 
         const request: SimpleRequest = {
             appName: this.request.appName,

--- a/src/views/Logout.vue
+++ b/src/views/Logout.vue
@@ -13,7 +13,10 @@ export default class Logout extends Vue {
 
     public async created() {
         const wallet = await WalletStore.Instance.get(this.request.walletId);
-        if (!wallet) throw new Error('Account ID not found');
+        if (!wallet) {
+            this.$rpc.reject(new Error('Account ID not found'));
+            return;
+        }
 
         const request: KeyguardClient.RemoveKeyRequest = {
             appName: this.request.appName,

--- a/src/views/Rename.vue
+++ b/src/views/Rename.vue
@@ -83,7 +83,10 @@ export default class Rename extends Vue {
 
     private async mounted() {
         const wallet = await WalletStore.Instance.get(this.request.walletId);
-        if (!wallet) throw new Error('Account ID not found');
+        if (!wallet) {
+            this.$rpc.reject(new Error('Account ID not found'));
+            return;
+        }
 
         this.wallet = wallet;
         // Wait for the next tick to update the DOM, then focus the correct label

--- a/src/views/SignTransaction.vue
+++ b/src/views/SignTransaction.vue
@@ -14,9 +14,16 @@ export default class SignTransaction extends Vue {
     public async created() {
         // Forward user through AccountsManager to Keyguard
         const wallet = await WalletStore.Instance.get(this.request.walletId);
-        if (!wallet) throw new Error('Account ID not found');
+        if (!wallet) {
+            this.$rpc.reject(new Error('Account ID not found'));
+            return;
+        }
         const account = wallet.accounts.get(this.request.sender.toUserFriendlyAddress());
-        if (!account) throw new Error('Sender address not found!'); // TODO Search contracts when address not found
+        if (!account) {
+            // TODO Search contracts when address not found
+            this.$rpc.reject(new Error('Address not found'));
+            return;
+        }
 
         const request: KeyguardClient.SignTransactionRequest = {
             layout: 'standard',


### PR DESCRIPTION
There was an error thrown through Sentry:

```
TypeError in done(src/views/Rename):
null is not an object (evaluating 'this.wallet.id')
./src/views/Rename.vue in done at line 126:29
```

This leads me to believe, that the request was not rejected when `mounted()` function found that the account ID does not exist.

Thus I now made it so that the requests are actually rejected when the account ID is not found.