### PR TITLE
Chrome Ledger support warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "@nimiq/network-client": "^0.1.5",
         "@nimiq/rpc": "^0.1.4",
         "@nimiq/style": "^0.4.1",
-        "@nimiq/utils": "^0.1.0",
+        "@nimiq/utils": "^0.3.0",
         "@nimiq/vue-components": "https://github.com/nimiq/vue-components.git#build/accounts",
         "vue": "^2.6.6",
         "vue-class-component": "^6.0.0",

--- a/src/components/LedgerUi.vue
+++ b/src/components/LedgerUi.vue
@@ -143,6 +143,10 @@ class LedgerUi extends Vue {
             case LedgerApi.ErrorType.NO_BROWSER_SUPPORT:
                 this._showInstructions('', 'Ledger not supported by browser or support not enabled.');
                 break;
+            case LedgerApi.ErrorType.INCOMPATIBLE_CHROME_VERSION:
+                this._showInstructions('',
+                    'Ledger currently not compatible with Chrome 72+. Please use Opera or Brave.');
+                break;
             case LedgerApi.ErrorType.APP_OUTDATED:
                 this._showInstructions('', 'Your Nimiq App is outdated. Please update using Ledger Live.');
                 break;
@@ -246,7 +250,6 @@ export default LedgerUi;
     }
 
     .loader {
-        flex-grow: 1;
         overflow: hidden;
     }
 

--- a/src/components/Loader.vue
+++ b/src/components/Loader.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="loader" :class="{ 'nq-blue-bq': showLoadingBackground && !lightBlue, 'nq-light-blue-bg': showLoadingBackground && lightBlue, 'exit-transition': state === 'success' }">
+    <div class="loader" :class="{ 'nq-blue-bg': showLoadingBackground && !lightBlue, 'nq-light-blue-bg': showLoadingBackground && lightBlue, 'exit-transition': state === 'success' }">
         <transition name="fade-loading">
             <div class="wrapper" v-if="state === 'loading'">
                 <h1 class="title nq-h1">{{ loadingTitle }}</h1>

--- a/src/components/Loader.vue
+++ b/src/components/Loader.vue
@@ -266,8 +266,11 @@ export default Loader;
     }
 
     .status-row {
+        --status-font-size: 2.5rem;
         margin-top: 2rem; /* Same as title margin-bottom, to equalize spacing to center icon */
         margin-bottom: 5rem;
+        height: var(--status-font-size); /* 1 line of status text. For multiple lines, the text overflows to the top */
+        position: relative;
     }
 
     .loader.small .status-row {
@@ -275,16 +278,18 @@ export default Loader;
     }
 
     .status {
-        line-height: 1;
+        position: absolute;
+        bottom: 0;
+        width: 100%;
         margin: 0;
+        padding: 0 2rem;
         font-weight: normal;
-        height: 2.5rem;
+        line-height: 1.2;
         opacity: 1;
     }
 
     .status.next {
-        margin-top: -2.5rem;
-        transform: translateY(2.5rem);
+        transform: translateY(var(--status-font-size));
         opacity: 0;
     }
 
@@ -293,7 +298,7 @@ export default Loader;
     }
 
     .status-row.transition .status.current {
-        transform: translateY(-2.5rem);
+        transform: translateY(calc(-1 * var(--status-font-size)));
         opacity: 0;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -760,10 +760,10 @@
   resolved "https://registry.yarnpkg.com/@nimiq/style/-/style-0.4.1.tgz#42b6e3a8ba4a0c7dbd71893b4149094466b48c49"
   integrity sha512-OLWRXTgtxOv0R5cOMZ3M2WCoardx6thGbZbxbpnWdhZkqoYnWqGp0oV5X5ic6Vde4mt403ogXwbfGtzwJknvrQ==
 
-"@nimiq/utils@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@nimiq/utils/-/utils-0.1.0.tgz#4586f2fad3909311484513c9e23dceae838c6dda"
-  integrity sha512-oN0AyYPkSowaAlgA1MjdbWjWzVHdd20cVH8uY9jpD+MulAl5s1yHxgNQKjgJjMZQFQMMOJjYHEPnf850t8V21g==
+"@nimiq/utils@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@nimiq/utils/-/utils-0.3.0.tgz#9e2e75c3072f6e276a41c9ddd4f0a7df010bff83"
+  integrity sha512-00aTQPtKpXIUz3ZJVrhWIjMPXvSvaY5SygDJwGIPDcP/KYii8FvqWqaYUoKfLe5dRwLxY4kM/Qdw6hWkLdWOBg==
 
 "@nimiq/vue-components@https://github.com/nimiq/vue-components.git#build/accounts":
   version "0.1.0"


### PR DESCRIPTION
Make the LedgerApi reject calls in Chrome 72+ and show a warning message as Chrome 72+ is currently incompatible with the ledger lib, see https://github.com/LedgerHQ/ledgerjs/issues/306.
The detection is done by user agent sniffing, as feature detection is probably not straight forward possible (Chrome 72+ fails only after some time with an unspecific timeout).

This requires https://github.com/nimiq/nimiq-utils/pull/21 to be merged first.