### PR TITLE
Omit default labels in cookie

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,6 +14,7 @@ module.exports = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
     'config': '<rootDir>/config.local.ts',
+    '@nimiq/iqons/dist/iqons-name.min.js': '@nimiq/iqons/dist/iqons-name.cjs.js',
   },
   snapshotSerializers: [
     'jest-serializer-vue'

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "postinstall": "cd client && yarn"
     },
     "dependencies": {
-        "@nimiq/iqons": "^1.4.0",
+        "@nimiq/iqons": "^1.4.1",
         "@nimiq/keyguard-client": "^0.2.8",
         "@nimiq/ledgerjs": "https://github.com/nimiq/ledger-api.git",
         "@nimiq/network-client": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "postinstall": "cd client && yarn"
     },
     "dependencies": {
-        "@nimiq/iqons": "^1.4.1",
+        "@nimiq/iqons": "^1.4.2",
         "@nimiq/keyguard-client": "^0.2.8",
         "@nimiq/ledgerjs": "https://github.com/nimiq/ledger-api.git",
         "@nimiq/network-client": "^0.1.5",

--- a/src/lib/CookieDecoder.ts
+++ b/src/lib/CookieDecoder.ts
@@ -9,6 +9,7 @@ import {
     ACCOUNT_DEFAULT_LABEL_LEDGER,
     LABEL_MAX_LENGTH,
 } from '@/lib/Constants';
+import LabelingMachine from './LabelingMachine';
 
 export class CookieDecoder {
     public static decode(str: string): WalletInfoEntry[] {
@@ -104,9 +105,13 @@ export class CookieDecoder {
         // Wallet label
         const walletLabelBytes = this.readBytes(bytes, labelLength);
 
-        const walletLabel = Utf8Tools.utf8ByteArrayToString(new Uint8Array(walletLabelBytes));
-
         const accounts = this.decodeAccounts(bytes, type);
+
+        const walletLabel = walletLabelBytes.length > 0
+            ? Utf8Tools.utf8ByteArrayToString(new Uint8Array(walletLabelBytes))
+            : type === WalletType.LEDGER
+                ? ACCOUNT_DEFAULT_LABEL_LEDGER
+                : LabelingMachine.labelAccount(this._toUserFriendlyAddress(accounts.values().next().value.address));
 
         const walletInfoEntry: WalletInfoEntry = {
             id,
@@ -157,11 +162,14 @@ export class CookieDecoder {
         // Account label
         const labelBytes = this.readBytes(bytes, labelLength);
 
-        const accountLabel = Utf8Tools.utf8ByteArrayToString(new Uint8Array(labelBytes));
 
         // Account address
         // (iframe does not have Nimiq lib)
         const addressBytes = this.readBytes(bytes, 20 /* Nimiq.Address.SERIALIZED_SIZE */);
+
+        const accountLabel = labelBytes.length > 0
+            ? Utf8Tools.utf8ByteArrayToString(new Uint8Array(labelBytes))
+            : LabelingMachine.labelAddress(this._toUserFriendlyAddress(new Uint8Array(addressBytes)));
 
         const accountInfoEntry: AccountInfoEntry = {
             path: 'not public',

--- a/src/lib/CookieDecoder.ts
+++ b/src/lib/CookieDecoder.ts
@@ -107,11 +107,12 @@ export class CookieDecoder {
 
         const accounts = this.decodeAccounts(bytes, type);
 
+        const firstAccount = accounts.values().next().value;
         const walletLabel = walletLabelBytes.length > 0
             ? Utf8Tools.utf8ByteArrayToString(new Uint8Array(walletLabelBytes))
             : type === WalletType.LEDGER
                 ? ACCOUNT_DEFAULT_LABEL_LEDGER
-                : LabelingMachine.labelAccount(this._toUserFriendlyAddress(accounts.values().next().value.address));
+                : LabelingMachine.labelAccount(this._toUserFriendlyAddress(firstAccount.address));
 
         const walletInfoEntry: WalletInfoEntry = {
             id,
@@ -161,7 +162,6 @@ export class CookieDecoder {
 
         // Account label
         const labelBytes = this.readBytes(bytes, labelLength);
-
 
         // Account address
         // (iframe does not have Nimiq lib)

--- a/src/lib/CookieJar.ts
+++ b/src/lib/CookieJar.ts
@@ -153,7 +153,7 @@ class CookieJar {
         // Wallet accounts
         const accounts = Array.from(wallet.accounts.values());
         for (const account of accounts) {
-            const label = this.checkAccountDefaultLabel(account.address, account.label)
+            const label = this.checkAccountDefaultLabel(account.address, account.label);
             const labelBytes = this.encodeAndcutLabel(label);
 
             // Account label length

--- a/tests/unit/CookieJar.spec.ts
+++ b/tests/unit/CookieJar.spec.ts
@@ -34,7 +34,7 @@ const DUMMY_WALLET_OBJECTS: WalletInfoEntry[] = [
                 DUMMY_ADDRESS_HR2,
                 {
                     path: 'm/0\'',
-                    label: '',
+                    label: 'Divine Jinxing Budgie',
                     address: DUMMY_ADDRESS_S2,
                 },
             ],
@@ -47,7 +47,7 @@ const DUMMY_WALLET_OBJECTS: WalletInfoEntry[] = [
     },
     {
         id: '1ee3d926a49d',
-        label: '',
+        label: 'Ledger Account',
         accounts: new Map<string, AccountInfoEntry>([
             [
                 BURN_ADDRESS_HR,
@@ -104,7 +104,7 @@ const DUMMY_WALLET_OBJECTS: WalletInfoEntry[] = [
                 DUMMY_ADDRESS_HR2,
                 {
                     path: 'm/0\'',
-                    label: '',
+                    label: 'Divine Jinxing Budgie',
                     address: DUMMY_ADDRESS_S2,
                 },
             ],
@@ -117,7 +117,7 @@ const DUMMY_WALLET_OBJECTS: WalletInfoEntry[] = [
     },
     {
         id: '1ee3d926a4a0',
-        label: '',
+        label: 'Ledger Account',
         accounts: new Map<string, AccountInfoEntry>([
             [
                 BURN_ADDRESS_HR,
@@ -177,7 +177,7 @@ const OUT_DUMMY_WALLET_OBJECTS: WalletInfoEntry[] = [
                 DUMMY_ADDRESS_HR2,
                 {
                     path: 'not public',
-                    label: '',
+                    label: 'Divine Jinxing Budgie',
                     address: DUMMY_ADDRESS_S2,
                 },
             ],
@@ -190,7 +190,7 @@ const OUT_DUMMY_WALLET_OBJECTS: WalletInfoEntry[] = [
     },
     {
         id: '1ee3d926a49d',
-        label: '',
+        label: 'Ledger Account',
         accounts: new Map<string, AccountInfoEntry>([
             [
                 BURN_ADDRESS_HR,
@@ -242,7 +242,7 @@ const OUT_DUMMY_WALLET_OBJECTS: WalletInfoEntry[] = [
                 DUMMY_ADDRESS_HR2,
                 {
                     path: 'not public',
-                    label: '',
+                    label: 'Divine Jinxing Budgie',
                     address: DUMMY_ADDRESS_S2,
                 },
             ],
@@ -255,7 +255,7 @@ const OUT_DUMMY_WALLET_OBJECTS: WalletInfoEntry[] = [
     },
     {
         id: '1ee3d926a4a0',
-        label: '',
+        label: 'Ledger Account',
         accounts: new Map<string, AccountInfoEntry>([
             [
                 BURN_ADDRESS_HR,

--- a/tests/unit/CookieJar.spec.ts
+++ b/tests/unit/CookieJar.spec.ts
@@ -20,12 +20,12 @@ const BURN_ADDRESS_S = new Uint8Array(BURN_ADDRESS.serialize());
 const DUMMY_WALLET_OBJECTS: WalletInfoEntry[] = [
     {
         id: 'K23',
-        label: 'Main 🙉',
+        label: 'Green Account',
         accounts: new Map<string, AccountInfoEntry>([
             [
                 DUMMY_ADDRESS_HR1,
                 {
-                    path: 'm/0\'',
+                    path: 'm/44\'/242\'/0\'/0\'',
                     label: 'MyAddress1',
                     address: DUMMY_ADDRESS_S1,
                 },
@@ -33,7 +33,7 @@ const DUMMY_WALLET_OBJECTS: WalletInfoEntry[] = [
             [
                 DUMMY_ADDRESS_HR2,
                 {
-                    path: 'm/0\'',
+                    path: 'm/44\'/242\'/0\'/5\'',
                     label: 'Divine Jinxing Budgie',
                     address: DUMMY_ADDRESS_S2,
                 },
@@ -47,12 +47,12 @@ const DUMMY_WALLET_OBJECTS: WalletInfoEntry[] = [
     },
     {
         id: '1ee3d926a49d',
-        label: 'Ledger Account',
+        label: 'Monkey Family 🙉',
         accounts: new Map<string, AccountInfoEntry>([
             [
                 BURN_ADDRESS_HR,
                 {
-                    path: 'm/0\'',
+                    path: 'm/44\'/242\'/0\'/0\'',
                     label: 'Daniel\'s Ledger ❤',
                     address: BURN_ADDRESS_S,
                 },
@@ -61,7 +61,7 @@ const DUMMY_WALLET_OBJECTS: WalletInfoEntry[] = [
         contracts: [{
             address: DUMMY_ADDRESS1,
             label: 'Savings',
-            ownerPath: 'm/0\'',
+            ownerPath: 'm/44\'/242\'/0\'/0\'',
             type: ContractType.VESTING,
         }],
         type: WalletType.LEDGER,
@@ -95,16 +95,16 @@ const DUMMY_WALLET_OBJECTS: WalletInfoEntry[] = [
             [
                 DUMMY_ADDRESS_HR1,
                 {
-                    path: 'm/0\'',
-                    label: 'MyAddress1',
+                    path: 'm/44\'/242\'/0\'/0\'',
+                    label: 'Fishy Chirping Fly',
                     address: DUMMY_ADDRESS_S1,
                 },
             ],
             [
                 DUMMY_ADDRESS_HR2,
                 {
-                    path: 'm/0\'',
-                    label: 'Divine Jinxing Budgie',
+                    path: 'm/44\'/242\'/0\'/5\'',
+                    label: 'MyAddress2',
                     address: DUMMY_ADDRESS_S2,
                 },
             ],
@@ -122,16 +122,16 @@ const DUMMY_WALLET_OBJECTS: WalletInfoEntry[] = [
             [
                 BURN_ADDRESS_HR,
                 {
-                    path: 'm/0\'',
-                    label: 'Daniel\'s Ledger ❤',
+                    path: 'm/44\'/242\'/0\'/0\'',
+                    label: 'Childish Scoring Warlock',
                     address: BURN_ADDRESS_S,
                 },
             ],
         ]),
         contracts: [{
             address: DUMMY_ADDRESS1,
-            label: 'Savings',
-            ownerPath: 'm/0\'',
+            label: 'Vesting Contract',
+            ownerPath: 'm/44\'/242\'/0\'/0\'',
             type: ContractType.VESTING,
         }],
         type: WalletType.LEDGER,
@@ -163,7 +163,7 @@ const DUMMY_WALLET_OBJECTS: WalletInfoEntry[] = [
 const OUT_DUMMY_WALLET_OBJECTS: WalletInfoEntry[] = [
     {
         id: 'K23',
-        label: 'Main 🙉',
+        label: 'Green Account',
         accounts: new Map<string, AccountInfoEntry>([
             [
                 DUMMY_ADDRESS_HR1,
@@ -190,7 +190,7 @@ const OUT_DUMMY_WALLET_OBJECTS: WalletInfoEntry[] = [
     },
     {
         id: '1ee3d926a49d',
-        label: 'Ledger Account',
+        label: 'Monkey Family 🙉',
         accounts: new Map<string, AccountInfoEntry>([
             [
                 BURN_ADDRESS_HR,
@@ -234,7 +234,7 @@ const OUT_DUMMY_WALLET_OBJECTS: WalletInfoEntry[] = [
                 DUMMY_ADDRESS_HR1,
                 {
                     path: 'not public',
-                    label: 'MyAddress1',
+                    label: 'Fishy Chirping Fly',
                     address: DUMMY_ADDRESS_S1,
                 },
             ],
@@ -242,7 +242,7 @@ const OUT_DUMMY_WALLET_OBJECTS: WalletInfoEntry[] = [
                 DUMMY_ADDRESS_HR2,
                 {
                     path: 'not public',
-                    label: 'Divine Jinxing Budgie',
+                    label: 'MyAddress2',
                     address: DUMMY_ADDRESS_S2,
                 },
             ],
@@ -261,7 +261,7 @@ const OUT_DUMMY_WALLET_OBJECTS: WalletInfoEntry[] = [
                 BURN_ADDRESS_HR,
                 {
                     path: 'not public',
-                    label: 'Daniel\'s Ledger ❤',
+                    label: 'Childish Scoring Warlock',
                     address: BURN_ADDRESS_S,
                 },
             ],
@@ -297,10 +297,10 @@ const BYTES = [
     1, // cookie version
 
     // wallet 1 (BIP39)
-    38, // wallet label length (9), wallet type (2)
+    2, // wallet label length (0), wallet type (2)
     1, // keyMissing = true, fileExported = false, wordsExported = false
     1, 23, // wallet id
-    77, 97, 105, 110, 32, 240, 159, 153, 137, // wallet label
+    // wallet label (omitted)
     2, // number of accounts
 
         // account 1
@@ -310,13 +310,14 @@ const BYTES = [
 
         // account 2
         0, // account label length
+        // account label (omitted)
         101, 254, 174, 109, 147, 234, 215, 10, 22, 16, 67, 70, 109, 90, 53, 154, 43, 22, 180, 254, // account address
 
     // wallet 2 (LEDGER)
-    3, // wallet label length (0), wallet type (3)
+    75, // wallet label length (18), wallet type (3)
     3, // keyMissing = true, fileExported = true, wordsExported = false
     30, 227, 217, 38, 164, 157, // wallet id
-    // wallet label (omitted)
+    77, 111, 110, 107, 101, 121, 32, 70, 97, 109, 105, 108, 121, 32, 240, 159, 153, 137, // wallet label
     1, // number of accounts
 
         // account 1
@@ -341,15 +342,16 @@ const BYTES = [
     2, // number of accounts
 
         // account 1
-        10, // account label length
-        77, 121, 65, 100, 100, 114, 101, 115, 115, 49, // account label
+        0, // account label length
+        // account label (omitted)
         51, 71, 19, 87, 173, 20, 186, 75, 28, 253, 125, 148, 90, 165, 116, 22, 53, 112, 220, 196, // account address
 
         // account 2
-        0, // account label length
+        10, // account label length
+        77, 121, 65, 100, 100, 114, 101, 115, 115, 50, // account label
         101, 254, 174, 109, 147, 234, 215, 10, 22, 16, 67, 70, 109, 90, 53, 154, 43, 22, 180, 254, // account address
 
-    // wallet 2 (LEDGER)
+    // wallet 5 (LEDGER)
     3, // wallet label length (0), wallet type (3)
     0, // keyMissing = false, fileExported = false, wordsExported = false
     30, 227, 217, 38, 164, 160, // wallet id
@@ -357,11 +359,11 @@ const BYTES = [
     1, // number of accounts
 
         // account 1
-        19, // account label length
-        68, 97, 110, 105, 101, 108, 39, 115, 32, 76, 101, 100, 103, 101, 114, 32, 226, 157, 164, // account label
+        0, // account label length
+        // account label (omitted)
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // account address
 
-    // wallet 3 (LEGACY)
+    // wallet 6 (LEGACY)
     41, // account label length (10), wallet type (1)
     2, // keyMissing = false, fileExported = true, wordsExported = false
     3, 137, 84, 64, // wallet id

--- a/tests/unit/CookieJar.spec.ts
+++ b/tests/unit/CookieJar.spec.ts
@@ -316,6 +316,7 @@ const BYTES = [
     3, // wallet label length (0), wallet type (3)
     3, // keyMissing = true, fileExported = true, wordsExported = false
     30, 227, 217, 38, 164, 157, // wallet id
+    // wallet label (omitted)
     1, // number of accounts
 
         // account 1
@@ -352,6 +353,7 @@ const BYTES = [
     3, // wallet label length (0), wallet type (3)
     0, // keyMissing = false, fileExported = false, wordsExported = false
     30, 227, 217, 38, 164, 160, // wallet id
+    // wallet label (omitted)
     1, // number of accounts
 
         // account 1

--- a/yarn.lock
+++ b/yarn.lock
@@ -707,10 +707,10 @@
     nan "^2.10.0"
     ws "^5.2.0"
 
-"@nimiq/iqons@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@nimiq/iqons/-/iqons-1.4.0.tgz#b20032734e8f3dd6f0f21a044d198320d2aa6dbc"
-  integrity sha512-pfxaaTYkuCUWrrUmJzpxU3gB2TXyX7gEnWHUrFJH8vsYoRUxa6jol91XSgOTnE51Aki5jd1KbHLYGiapvrkHPQ==
+"@nimiq/iqons@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@nimiq/iqons/-/iqons-1.4.1.tgz#c00b9c790ddb788a12a02164069847e5f315d750"
+  integrity sha512-MoIoZlD0AOv0bg+G1KS4pgf+p3g9vgHPXZOu6djqcwGJhEj8gbk//vza2Y2szFbOvQqdThFvoMdDD8gWakZKDQ==
   dependencies:
     dom-parser "^0.1.5"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -707,10 +707,10 @@
     nan "^2.10.0"
     ws "^5.2.0"
 
-"@nimiq/iqons@^1.4.1":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@nimiq/iqons/-/iqons-1.4.1.tgz#c00b9c790ddb788a12a02164069847e5f315d750"
-  integrity sha512-MoIoZlD0AOv0bg+G1KS4pgf+p3g9vgHPXZOu6djqcwGJhEj8gbk//vza2Y2szFbOvQqdThFvoMdDD8gWakZKDQ==
+"@nimiq/iqons@^1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@nimiq/iqons/-/iqons-1.4.2.tgz#be8c9b8f219783e5fc912726caa375dcce0be447"
+  integrity sha512-fEn4a1mHpSuQexjKpiekYgicaui3MtPptvfSReSOtyPleJbsyb9CSrdDkFuhPVaS88/jxyodjLscRMO4FAPdmw==
   dependencies:
     dom-parser "^0.1.5"
 


### PR DESCRIPTION
Testing of the removal and re-setting of the default labels is done via the byte-check of the encoded cookie (the labels are empty in the cookie bytes).