### PR TITLE
Add add-address flow for ledger

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "@nimiq/network-client": "^0.1.5",
         "@nimiq/rpc": "^0.1.4",
         "@nimiq/style": "^0.4.1",
-        "@nimiq/utils": "^0.3.0",
+        "@nimiq/utils": "^0.3.1",
         "@nimiq/vue-components": "https://github.com/nimiq/vue-components.git#build/accounts",
         "vue": "^2.6.6",
         "vue-class-component": "^6.0.0",

--- a/src/components/LedgerUi.vue
+++ b/src/components/LedgerUi.vue
@@ -115,7 +115,7 @@ class LedgerUi extends Vue {
                 break;
             case LedgerApi.RequestType.DERIVE_ACCOUNTS:
                 // not interactive, but takes ~6 seconds
-                this._showInstructions('Fetching Accounts');
+                this._showInstructions('Fetching Addresses');
                 break;
             case LedgerApi.RequestType.CONFIRM_ADDRESS:
                 this._showInstructions('Confirm Address',

--- a/src/components/Loader.vue
+++ b/src/components/Loader.vue
@@ -351,7 +351,7 @@ export default Loader;
     .loader .title {
         line-height: 1;
         margin-top: 4rem;
-        white-space: pre;
+        white-space: pre-line;
     }
 
     .loader .loader.small .title {

--- a/src/components/WalletIdentifier.vue
+++ b/src/components/WalletIdentifier.vue
@@ -50,7 +50,7 @@ export default class WalletIdentifier extends Vue {
     }
 
     .pop-in {
-        animation: pop-in 0.5s cubic-bezier(.73,2.08,.48,1) backwards;
+        animation: pop-in 0.5s cubic-bezier(.73,2.08,.48,1) both;
     }
 
     @keyframes pop-in {

--- a/src/lib/LedgerApi.ts
+++ b/src/lib/LedgerApi.ts
@@ -210,6 +210,12 @@ class LedgerApi {
         return `${LedgerApi.BIP32_BASE_PATH}${keyId}'`;
     }
 
+    public static getKeyIdForBip32Path(path: string): number | null {
+        const pathMatch = LedgerApi.BIP32_PATH_REGEX.exec(path);
+        if (!pathMatch) return null;
+        return parseInt(pathMatch[pathMatch.length - 1], 10);
+    }
+
     public static async deriveAccounts(pathsToDerive: Iterable<string>, walletId?: string)
         : Promise<Array<{ address: string, keyPath: string }>> {
         const request = new LedgerApiRequest(LedgerApi.RequestType.DERIVE_ACCOUNTS,

--- a/src/router.ts
+++ b/src/router.ts
@@ -19,7 +19,7 @@ const Signup                  = () => import(/*webpackChunkName: "onboarding"*/ 
 const SignupSuccess           = () => import(/*webpackChunkName: "onboarding"*/ './views/SignupSuccess.vue');
 const SignupErrorHandler      = () => import(/*webpackChunkName: "onboarding"*/ './views/SignupErrorHandler.vue');
 
-const SignupLedger            = () => import(/*webpackChunkName: "signup-ledger"*/ './views/SignupLedger.vue');
+const SignupLedger            = () => import(/*webpackChunkName: "add-ledger"*/ './views/SignupLedger.vue');
 
 const Login                   = () => import(/*webpackChunkName: "onboarding"*/ './views/Login.vue');
 const LoginSuccess            = () => import(/*webpackChunkName: "onboarding"*/ './views/LoginSuccess.vue');
@@ -35,6 +35,7 @@ const LogoutSuccess           = () => import(/*webpackChunkName: "logout"*/ './v
 
 const AddAccount              = () => import(/*webpackChunkName: "add-account"*/ './views/AddAccount.vue');
 const AddAccountSuccess       = () => import(/*webpackChunkName: "add-account"*/ './views/AddAccountSuccess.vue');
+const AddAddressLedger        = () => import(/*webpackChunkName: "add-ledger"*/ './views/AddAddressLedger.vue');
 
 const Rename                  = () => import(/*webpackChunkName: "rename"*/ './views/Rename.vue');
 
@@ -147,11 +148,6 @@ export default new Router({
             name: RequestType.SIGNUP,
         },
         {
-            path: `/${RequestType.SIGNUP}/ledger`,
-            component: SignupLedger,
-            name: `${RequestType.SIGNUP}-ledger`,
-        },
-        {
             path: `/${RequestType.SIGNUP}/success`,
             component: SignupSuccess,
             name: `${RequestType.SIGNUP}-success`,
@@ -160,6 +156,11 @@ export default new Router({
             path: `/${RequestType.SIGNUP}/error`,
             component: SignupErrorHandler,
             name: `${RequestType.SIGNUP}-error`,
+        },
+        {
+            path: `/${RequestType.SIGNUP}/ledger`,
+            component: SignupLedger,
+            name: `${RequestType.SIGNUP}-ledger`,
         },
         {
             path: `/${RequestType.LOGIN}`,
@@ -215,6 +216,11 @@ export default new Router({
             path: `/${RequestType.ADD_ADDRESS}/success`,
             component: AddAccountSuccess,
             name: `${RequestType.ADD_ADDRESS}-success`,
+        },
+        {
+            path: `/${RequestType.ADD_ADDRESS}/ledger`,
+            component: AddAddressLedger,
+            name: `${RequestType.ADD_ADDRESS}-ledger`,
         },
         {
             path: `/${RequestType.RENAME}`,

--- a/src/views/AddAddressLedger.vue
+++ b/src/views/AddAddressLedger.vue
@@ -16,7 +16,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Emit, Vue } from 'vue-property-decorator';
+import { Component, Vue } from 'vue-property-decorator';
 import { PageBody, SmallPage } from '@nimiq/vue-components';
 import LedgerUi from '../components/LedgerUi.vue';
 import Loader from '../components/Loader.vue';
@@ -95,10 +95,8 @@ export default class AddAddressLedger extends Vue {
             label: selectedAccount.label,
         };
         this.$rpc.resolve(result);
-        this.$emit('done');
     }
 
-    @Emit()
     private close() {
         this.$rpc.reject(new Error(ERROR_CANCELED));
     }

--- a/src/views/AddAddressLedger.vue
+++ b/src/views/AddAddressLedger.vue
@@ -1,0 +1,112 @@
+<template>
+    <div class="container">
+        <SmallPage>
+            <LedgerUi v-if="state === 'ledger-interaction'"></LedgerUi>
+            <IdenticonSelector v-else-if="state === 'identicon-selection'" :accounts="addressesToSelectFrom"
+                               :confirmAccountSelection="false" @identicon-selected="_onAddressSelected">
+            </IdenticonSelector>
+            <Loader v-if="state === 'finished'" state="success" title="Address Added"></Loader>
+        </SmallPage>
+
+        <button class="global-close nq-button-s" @click="close">
+            <span class="nq-icon arrow-left"></span>
+            Back to {{request.appName}}
+        </button>
+    </div>
+</template>
+
+<script lang="ts">
+import { Component, Emit, Vue } from 'vue-property-decorator';
+import { PageBody, SmallPage } from '@nimiq/vue-components';
+import LedgerUi from '../components/LedgerUi.vue';
+import Loader from '../components/Loader.vue';
+import IdenticonSelector from '../components/IdenticonSelector.vue';
+import { Static } from '../lib/StaticStore';
+import { ParsedSimpleRequest } from '../lib/RequestTypes';
+import { Address } from '../lib/PublicRequestTypes';
+import { WalletInfo } from '../lib/WalletInfo';
+import { AccountInfo } from '../lib/AccountInfo';
+import LedgerApi from '../lib/LedgerApi';
+import { WalletStore } from '../lib/WalletStore';
+import { ACCOUNT_MAX_ALLOWED_ADDRESS_GAP, ERROR_CANCELED } from '../lib/Constants';
+import LabelingMachine from '../lib/LabelingMachine';
+
+@Component({components: {PageBody, SmallPage, LedgerUi, Loader, IdenticonSelector}})
+export default class AddAddressLedger extends Vue {
+    private static readonly State = {
+        LEDGER_INTERACTION: 'ledger-interaction', // can be instructions to connect or also display of an error
+        IDENTICON_SELECTION: 'identicon-selection',
+        FINISHED: 'finished',
+    };
+
+    @Static private request!: ParsedSimpleRequest;
+
+    private state: string = AddAddressLedger.State.LEDGER_INTERACTION;
+    private account!: WalletInfo;
+    private addressesToSelectFrom: AccountInfo[] = [];
+
+    private async created() {
+        // called every time the router shows this page
+        const account = await WalletStore.Instance.get(this.request.walletId);
+        if (!account) {
+            this.$rpc.reject(new Error('Account ID not found'));
+            return;
+        }
+        this.account = account;
+
+        let startIndex = 0;
+        const newestAddress = Array.from(account.accounts.values()).pop();
+        if (newestAddress) {
+            const newestIndex = LedgerApi.getKeyIdForBip32Path(newestAddress.path);
+            startIndex = (newestIndex !== null ? newestIndex : -1) + 1;
+        }
+
+        const pathsToDerive = [];
+        for (let keyId = startIndex; keyId < startIndex + ACCOUNT_MAX_ALLOWED_ADDRESS_GAP; ++keyId) {
+            pathsToDerive.push(LedgerApi.getBip32PathForKeyId(keyId));
+        }
+
+        const derivedAddressInfos = await LedgerApi.deriveAccounts(pathsToDerive, this.request.walletId);
+        this.addressesToSelectFrom = derivedAddressInfos.map((addressInfo) => new AccountInfo(
+            addressInfo.keyPath,
+            LabelingMachine.labelAddress(addressInfo.address),
+            Nimiq.Address.fromUserFriendlyAddress(addressInfo.address),
+            0, // balance 0 because user selects from unused addresses
+        ));
+        this.state = AddAddressLedger.State.IDENTICON_SELECTION;
+    }
+
+    private destroyed() {
+        const currentRequest = LedgerApi.currentRequest;
+        if (currentRequest && currentRequest.type === LedgerApi.RequestType.DERIVE_ACCOUNTS) {
+            currentRequest.cancel();
+        }
+    }
+
+    private async _onAddressSelected(selectedAccount: AccountInfo) {
+        const userFriendlyAddress = selectedAccount.userFriendlyAddress;
+        this.account.accounts.set(userFriendlyAddress, selectedAccount);
+        await WalletStore.Instance.put(this.account);
+
+        this.state = AddAddressLedger.State.FINISHED;
+        await new Promise((resolve) => setTimeout(resolve, Loader.SUCCESS_REDIRECT_DELAY));
+        const result: Address = {
+            address: userFriendlyAddress,
+            label: selectedAccount.label,
+        };
+        this.$rpc.resolve(result);
+        this.$emit('done');
+    }
+
+    @Emit()
+    private close() {
+        this.$rpc.reject(new Error(ERROR_CANCELED));
+    }
+}
+</script>
+
+<style scoped>
+    .small-page > * {
+        flex-grow: 1;
+    }
+</style>

--- a/src/views/Checkout.vue
+++ b/src/views/Checkout.vue
@@ -47,7 +47,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Emit, Watch, Vue } from 'vue-property-decorator';
+import { Component, Vue } from 'vue-property-decorator';
 import { PaymentInfoLine, AccountSelector, AccountInfo as AccountInfoScreen, SmallPage } from '@nimiq/vue-components';
 import { ParsedCheckoutRequest, RequestType } from '../lib/RequestTypes';
 import { Account } from '../lib/PublicRequestTypes';
@@ -217,7 +217,6 @@ export default class Checkout extends Vue {
         }
     }
 
-    @Emit()
     private close() {
         this.$rpc.reject(new Error(ERROR_CANCELED));
     }

--- a/src/views/CheckoutTransmission.vue
+++ b/src/views/CheckoutTransmission.vue
@@ -9,7 +9,6 @@
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
-import { SignedTransaction } from '../lib/PublicRequestTypes';
 import { Static } from '../lib/StaticStore';
 import { State } from 'vuex-class';
 import { SmallPage } from '@nimiq/vue-components';

--- a/src/views/ChooseAddress.vue
+++ b/src/views/ChooseAddress.vue
@@ -22,7 +22,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue, Emit } from 'vue-property-decorator';
+import { Component, Vue } from 'vue-property-decorator';
 import { Getter, Mutation } from 'vuex-class';
 import { SmallPage, AccountSelector } from '@nimiq/vue-components';
 import { RequestType } from '../lib/RequestTypes';
@@ -111,7 +111,6 @@ export default class ChooseAddress extends Vue {
         delete staticStore.sideResult;
     }
 
-    @Emit()
     private close() {
         this.$rpc.reject(new Error(ERROR_CANCELED));
     }

--- a/src/views/LoginSuccess.vue
+++ b/src/views/LoginSuccess.vue
@@ -7,17 +7,16 @@
 </template>
 
 <script lang="ts">
-import { Component, Emit, Vue } from 'vue-property-decorator';
-import { ParsedBasicRequest, RequestType } from '../lib/RequestTypes';
+import { Component, Vue } from 'vue-property-decorator';
+import { ParsedBasicRequest } from '../lib/RequestTypes';
 import { Account } from '../lib/PublicRequestTypes';
 import { State } from 'vuex-class';
-import { WalletInfo, WalletType } from '../lib/WalletInfo';
+import { WalletInfo } from '../lib/WalletInfo';
 import { WalletStore } from '@/lib/WalletStore';
 import { Static } from '@/lib/StaticStore';
 import { SmallPage } from '@nimiq/vue-components';
 import Loader from '@/components/Loader.vue';
 import WalletInfoCollector from '@/lib/WalletInfoCollector';
-import Input from '@/components/Input.vue';
 import KeyguardClient from '@nimiq/keyguard-client';
 
 @Component({components: {Loader, SmallPage}})
@@ -66,7 +65,6 @@ export default class LoginSuccess extends Vue {
         });
     }
 
-    @Emit()
     private done() {
         if (!this.walletInfos.length) throw new Error('WalletInfo not ready.');
         const result: Account = {

--- a/src/views/LogoutSuccess.vue
+++ b/src/views/LogoutSuccess.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Emit, Vue } from 'vue-property-decorator';
+import { Component, Vue } from 'vue-property-decorator';
 import { ParsedSimpleRequest } from '../lib/RequestTypes';
 import { SimpleResult } from '../lib/PublicRequestTypes';
 import { State } from 'vuex-class';

--- a/src/views/OnboardingSelector.vue
+++ b/src/views/OnboardingSelector.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Emit, Vue } from 'vue-property-decorator';
+import { Component, Vue } from 'vue-property-decorator';
 import { OnboardingMenu } from '@nimiq/vue-components';
 import { ParsedBasicRequest, RequestType } from '@/lib/RequestTypes';
 import { Static } from '@/lib/StaticStore';
@@ -44,7 +44,6 @@ export default class OnboardingSelector extends Vue {
         this.$rpc.routerPush(`${RequestType.SIGNUP}-ledger`);
     }
 
-    @Emit()
     private close() {
         this.$rpc.reject(new Error(ERROR_CANCELED));
     }

--- a/src/views/Rename.vue
+++ b/src/views/Rename.vue
@@ -32,7 +32,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue, Emit } from 'vue-property-decorator';
+import { Component, Vue } from 'vue-property-decorator';
 import { AccountList, SmallPage, PageHeader, PageBody, PageFooter } from '@nimiq/vue-components';
 import Input from '@/components/Input.vue';
 import { ParsedRenameRequest } from '../lib/RequestTypes';
@@ -140,7 +140,6 @@ export default class Rename extends Vue {
         this.$rpc.resolve(result);
     }
 
-    @Emit()
     private close() {
         this.$rpc.reject(new Error(ERROR_CANCELED));
     }

--- a/src/views/SignMessage.vue
+++ b/src/views/SignMessage.vue
@@ -25,7 +25,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Emit, Vue } from 'vue-property-decorator';
+import { Component, Vue } from 'vue-property-decorator';
 import { Getter, Mutation } from 'vuex-class';
 import { SmallPage, AccountSelector } from '@nimiq/vue-components';
 import { RequestType, ParsedSignMessageRequest } from '../lib/RequestTypes';
@@ -148,7 +148,6 @@ export default class SignMessage extends Vue {
         delete staticStore.sideResult;
     }
 
-    @Emit()
     private close() {
         this.$rpc.reject(new Error(ERROR_CANCELED));
     }

--- a/src/views/SignMessageSuccess.vue
+++ b/src/views/SignMessageSuccess.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Emit, Vue } from 'vue-property-decorator';
+import { Component, Vue } from 'vue-property-decorator';
 import { State } from 'vuex-class';
 import { ParsedSignMessageRequest } from '../lib/RequestTypes';
 import { SignedMessage } from '../lib/PublicRequestTypes';
@@ -29,7 +29,6 @@ export default class SignMessageSuccess extends Vue {
     @Static private keyguardRequest!: KeyguardClient.SignMessageRequest;
     @State private keyguardResult!: KeyguardClient.SignMessageResult;
 
-    @Emit()
     private mounted() {
         const result: SignedMessage = {
             signer: new Nimiq.Address(new Uint8Array(this.keyguardRequest.signer)).toUserFriendlyAddress(),

--- a/src/views/SignupLedger.vue
+++ b/src/views/SignupLedger.vue
@@ -25,7 +25,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Emit, Vue } from 'vue-property-decorator';
+import { Component, Vue } from 'vue-property-decorator';
 import { PageBody, SmallPage } from '@nimiq/vue-components';
 import { ParsedBasicRequest } from '../lib/RequestTypes';
 import { Account } from '../lib/PublicRequestTypes';
@@ -154,7 +154,6 @@ export default class SignupLedger extends Vue {
         this.$forceUpdate(); // because vue does not recognize changes in walletInfo.accounts map // TODO verify
     }
 
-    @Emit()
     private async done() {
         this.state = SignupLedger.State.FINISHED;
         setTimeout(() => {
@@ -193,7 +192,6 @@ export default class SignupLedger extends Vue {
         }
     }
 
-    @Emit()
     private close() {
         this.$rpc.reject(new Error(ERROR_CANCELED));
     }

--- a/src/views/SignupSuccess.vue
+++ b/src/views/SignupSuccess.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue } from 'vue-property-decorator';
+import { Component, Vue } from 'vue-property-decorator';
 import { SmallPage } from '@nimiq/vue-components';
 import { AccountInfo } from '../lib/AccountInfo';
 import { WalletInfo, WalletType } from '../lib/WalletInfo';

--- a/src/views/SimpleSuccess.vue
+++ b/src/views/SimpleSuccess.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Emit, Vue } from 'vue-property-decorator';
+import { Component, Vue } from 'vue-property-decorator';
 import { SmallPage } from '@nimiq/vue-components';
 import { State } from 'vuex-class';
 import { RpcRequest, SimpleResult } from '../lib/PublicRequestTypes';

--- a/yarn.lock
+++ b/yarn.lock
@@ -767,10 +767,10 @@
   resolved "https://registry.yarnpkg.com/@nimiq/style/-/style-0.4.1.tgz#42b6e3a8ba4a0c7dbd71893b4149094466b48c49"
   integrity sha512-OLWRXTgtxOv0R5cOMZ3M2WCoardx6thGbZbxbpnWdhZkqoYnWqGp0oV5X5ic6Vde4mt403ogXwbfGtzwJknvrQ==
 
-"@nimiq/utils@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@nimiq/utils/-/utils-0.3.0.tgz#9e2e75c3072f6e276a41c9ddd4f0a7df010bff83"
-  integrity sha512-00aTQPtKpXIUz3ZJVrhWIjMPXvSvaY5SygDJwGIPDcP/KYii8FvqWqaYUoKfLe5dRwLxY4kM/Qdw6hWkLdWOBg==
+"@nimiq/utils@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@nimiq/utils/-/utils-0.3.1.tgz#f3bcd0800db207316cac754ff6548a1030290a5c"
+  integrity sha512-DONU//nAegIJHElIPpChbwzcUyA8piuGYeaGeQuGxdn8uCNzjGz8IZwGfnVYLwNONLswkYQQoRsxDsHypqdv3A==
 
 "@nimiq/vue-components@https://github.com/nimiq/vue-components.git#build/accounts":
   version "0.1.0"


### PR DESCRIPTION
Initilly I tried to refactor `SignupLedger` such that `AddAddresLedger` and `AddAddressLedger` would inherit from a common abstract base class. But in the end it turned out more beautiful to separate bothm implementations.

Note that I still want to improve the visual style of this flow (e.g. state transitions, loading spinner) but will do this together with style changes to `SignupLedger`