### PR TITLE
Check for invalid account in rpc api already and allow logout of deleted accounts

### DIFF
--- a/src/lib/RpcApi.ts
+++ b/src/lib/RpcApi.ts
@@ -138,7 +138,7 @@ export default class RpcApi {
                     request = RequestParser.parse(arg, state, requestType) || undefined;
                     this._staticStore.request = request;
                 } catch (error) {
-                    state.reply(ResponseStatus.ERROR, error);
+                    this.reject(error);
                     return;
                 }
 
@@ -154,7 +154,7 @@ export default class RpcApi {
                     account = await WalletStore.Instance.get((request as ParsedSimpleRequest).walletId);
                     if (!account && requestType !== RequestType.LOGOUT) {
                         // no account found although it's required
-                        state.reply(ResponseStatus.ERROR, new Error('Account ID not found'));
+                        this.reject(new Error('Account ID not found'));
                         return;
                     }
                 }
@@ -226,7 +226,7 @@ export default class RpcApi {
                 this._recoverState(state);
 
                 if (error.message === ERROR_CANCELED) {
-                    this._staticStore.rpcState!.reply(ResponseStatus.ERROR, error);
+                    this.reject(error);
                     return;
                 }
 

--- a/src/lib/RpcApi.ts
+++ b/src/lib/RpcApi.ts
@@ -147,17 +147,22 @@ export default class RpcApi {
                     hasRequest: !!this._staticStore.request,
                 });
 
-                if (location.pathname !== '/') {
-                    // Don't jump back to request's initial view on reload when navigated to a subsequent view.
-                    // E.g. if the user switches from Checkout to Import, don't jump back to Checkout on reload.
-                    return;
-                }
-
                 let account;
                 // Simply testing if the property exists (with `'walletId' in request`) is not enough,
                 // as `undefined` also counts as existing.
                 if (request && (request as ParsedSimpleRequest).walletId) {
                     account = await WalletStore.Instance.get((request as ParsedSimpleRequest).walletId);
+                    if (!account) {
+                        // no account found although it's required
+                        state.reply(ResponseStatus.ERROR, new Error('Account ID not found'));
+                        return;
+                    }
+                }
+
+                if (location.pathname !== '/') {
+                    // Don't jump back to request's initial view on reload when navigated to a subsequent view.
+                    // E.g. if the user switches from Checkout to Import, don't jump back to Checkout on reload.
+                    return;
                 }
 
                 if (account && account.type === WalletType.LEDGER

--- a/src/lib/RpcApi.ts
+++ b/src/lib/RpcApi.ts
@@ -152,7 +152,7 @@ export default class RpcApi {
                 // as `undefined` also counts as existing.
                 if (request && (request as ParsedSimpleRequest).walletId) {
                     account = await WalletStore.Instance.get((request as ParsedSimpleRequest).walletId);
-                    if (!account) {
+                    if (!account && requestType !== RequestType.LOGOUT) {
                         // no account found although it's required
                         state.reply(ResponseStatus.ERROR, new Error('Account ID not found'));
                         return;

--- a/src/views/AddAccount.vue
+++ b/src/views/AddAccount.vue
@@ -13,11 +13,7 @@ export default class AddAccount extends Vue {
     @Static private request!: ParsedSimpleRequest;
 
     public async created() {
-        const wallet = await WalletStore.Instance.get(this.request.walletId);
-        if (!wallet) {
-            this.$rpc.reject(new Error('Account ID not found'));
-            return;
-        }
+        const wallet = (await WalletStore.Instance.get(this.request.walletId))!;
         if (wallet.type === WalletType.LEGACY) {
             this.$rpc.reject(new Error('Cannot add address to single-address account'));
             return;

--- a/src/views/AddAccountSuccess.vue
+++ b/src/views/AddAccountSuccess.vue
@@ -35,8 +35,7 @@ export default class AddAccountSuccess extends Vue {
     private async mounted() {
         const createdAddress = new Nimiq.Address(this.keyguardResult.address);
 
-        const wallet = await WalletStore.Instance.get(this.request.walletId);
-        if (!wallet) throw new Error('Account ID not found');
+        const wallet = (await WalletStore.Instance.get(this.request.walletId))!;
 
         const newAccount = new AccountInfo(
             this.keyguardResult.keyPath,

--- a/src/views/AddAddressLedger.vue
+++ b/src/views/AddAddressLedger.vue
@@ -47,11 +47,7 @@ export default class AddAddressLedger extends Vue {
 
     private async created() {
         // called every time the router shows this page
-        const account = await WalletStore.Instance.get(this.request.walletId);
-        if (!account) {
-            this.$rpc.reject(new Error('Account ID not found'));
-            return;
-        }
+        const account = (await WalletStore.Instance.get(this.request.walletId))!;
         this.account = account;
 
         let startIndex = 0;

--- a/src/views/ChangePassword.vue
+++ b/src/views/ChangePassword.vue
@@ -12,11 +12,7 @@ export default class ChangePassword extends Vue {
     @Static private request!: ParsedSimpleRequest;
 
     public async created() {
-        const wallet = await WalletStore.Instance.get(this.request.walletId);
-        if (!wallet) {
-            this.$rpc.reject(new Error('Account ID not found'));
-            return;
-        }
+        const wallet = (await WalletStore.Instance.get(this.request.walletId))!;
 
         const request: KeyguardClient.SimpleRequest = {
             appName: this.request.appName,

--- a/src/views/Export.vue
+++ b/src/views/Export.vue
@@ -12,11 +12,7 @@ export default class Export extends Vue {
     @Static private request!: ParsedSimpleRequest;
 
     public async created() {
-        const wallet = await WalletStore.Instance.get(this.request.walletId);
-        if (!wallet) {
-            this.$rpc.reject(new Error('Account ID not found'));
-            return;
-        }
+        const wallet = (await WalletStore.Instance.get(this.request.walletId))!;
 
         const request: SimpleRequest = {
             appName: this.request.appName,

--- a/src/views/ExportSuccess.vue
+++ b/src/views/ExportSuccess.vue
@@ -28,14 +28,8 @@ export default class ExportSuccess extends Vue {
     @Static private request!: ParsedSimpleRequest;
     @State private keyguardResult!: KeyguardClient.ExportResult;
 
-    @Getter private findWallet!: (id: string) => WalletInfo | undefined;
-
     private async mounted() {
-        const wallet = this.findWallet(this.request.walletId);
-        if (!wallet) {
-            this.$rpc.reject(new Error('walletId not found'));
-            return;
-        }
+        const wallet = (await WalletStore.Instance.get(this.request.walletId))!;
 
         wallet.fileExported = wallet.fileExported || this.keyguardResult.fileExported;
         wallet.wordsExported = wallet.wordsExported || this.keyguardResult.wordsExported;

--- a/src/views/ExportSuccess.vue
+++ b/src/views/ExportSuccess.vue
@@ -16,7 +16,7 @@ import { Component, Vue } from 'vue-property-decorator';
 import { SmallPage } from '@nimiq/vue-components';
 import { ParsedSimpleRequest } from '../lib/RequestTypes';
 import { ExportResult } from '../lib/PublicRequestTypes';
-import { State, Getter } from 'vuex-class';
+import { State } from 'vuex-class';
 import { Static } from '@/lib/StaticStore';
 import Loader from '@/components/Loader.vue';
 import { WalletInfo } from '@/lib/WalletInfo';

--- a/src/views/Logout.vue
+++ b/src/views/Logout.vue
@@ -13,15 +13,11 @@ export default class Logout extends Vue {
 
     public async created() {
         const wallet = await WalletStore.Instance.get(this.request.walletId);
-        if (!wallet) {
-            this.$rpc.reject(new Error('Account ID not found'));
-            return;
-        }
 
         const request: KeyguardClient.RemoveKeyRequest = {
             appName: this.request.appName,
             keyId: this.request.walletId,
-            keyLabel: wallet.label,
+            keyLabel: !!wallet ? wallet.label : 'I want to log out', // the label to type in Keyguard to confirm logout
         };
 
         const client = this.$rpc.createKeyguardClient();

--- a/src/views/Rename.vue
+++ b/src/views/Rename.vue
@@ -85,13 +85,8 @@ export default class Rename extends Vue {
     }
 
     private async mounted() {
-        const wallet = await WalletStore.Instance.get(this.request.walletId);
-        if (!wallet) {
-            this.$rpc.reject(new Error('Account ID not found'));
-            return;
-        }
+        this.wallet = (await WalletStore.Instance.get(this.request.walletId))!;
 
-        this.wallet = wallet;
         // Wait for the next tick to update the DOM, then focus the correct label
         Vue.nextTick(this.focusElement);
 


### PR DESCRIPTION
Waiting for https://github.com/nimiq/accounts/pull/183 to be merged first.

- Check for existence of account required for a request in `RpcApi` already without the need to load the request view.
- Allow logout from account in Keyguard even if it was deleted (e.g by the browser) in the accounts manager database