### PR TITLE
Skip getting balance for imported legacy account

### DIFF
--- a/src/lib/WalletInfoCollector.ts
+++ b/src/lib/WalletInfoCollector.ts
@@ -52,7 +52,7 @@ export default class WalletInfoCollector {
         const walletInfo = await WalletInfoCollector._getWalletInfoInstance(walletId, walletType);
 
         // Add initial accounts to the walletInfo
-        let initialAccountsPromise;
+        let initialAccountsPromise = Promise.resolve();
         if (initialAccounts && initialAccounts.length > 0) {
             WalletInfoCollector._addAccounts(walletInfo, initialAccounts, undefined);
 
@@ -63,8 +63,6 @@ export default class WalletInfoCollector {
                     onUpdate(walletInfo, await derivedAccountsPromise);
                 });
             }
-        } else {
-            initialAccountsPromise = Promise.resolve();
         }
         onUpdate(walletInfo, await derivedAccountsPromise);
 

--- a/src/lib/WalletInfoCollector.ts
+++ b/src/lib/WalletInfoCollector.ts
@@ -55,11 +55,14 @@ export default class WalletInfoCollector {
         let initialAccountsPromise;
         if (initialAccounts && initialAccounts.length > 0) {
             WalletInfoCollector._addAccounts(walletInfo, initialAccounts, undefined);
-            // fetch balances and update again
-            initialAccountsPromise = WalletInfoCollector._getBalances(initialAccounts).then(async (balances) => {
-                WalletInfoCollector._addAccounts(walletInfo, initialAccounts, balances);
-                onUpdate(walletInfo, await derivedAccountsPromise);
-            });
+
+            if (walletInfo.type !== WalletType.LEGACY) {
+                // fetch balances and update again
+                initialAccountsPromise = WalletInfoCollector._getBalances(initialAccounts).then(async (balances) => {
+                    WalletInfoCollector._addAccounts(walletInfo, initialAccounts, balances);
+                    onUpdate(walletInfo, await derivedAccountsPromise);
+                });
+            }
         } else {
             initialAccountsPromise = Promise.resolve();
         }

--- a/src/lib/WalletInfoCollector.ts
+++ b/src/lib/WalletInfoCollector.ts
@@ -56,7 +56,7 @@ export default class WalletInfoCollector {
         if (initialAccounts && initialAccounts.length > 0) {
             WalletInfoCollector._addAccounts(walletInfo, initialAccounts, undefined);
 
-            if (walletInfo.type !== WalletType.LEGACY) {
+            if (walletType !== WalletType.LEGACY) {
                 // fetch balances and update again
                 initialAccountsPromise = WalletInfoCollector._getBalances(initialAccounts).then(async (balances) => {
                     WalletInfoCollector._addAccounts(walletInfo, initialAccounts, balances);


### PR DESCRIPTION
This prevents having to wait for balance when the only possible account is already known. The balance is currently not used anywhere in Accounts, is also checked separately from the Safe and is checked again in Accounts before Checkout.

Resolves #175.