### PR TITLE
Add support for contracts

### DIFF
--- a/demos/Demo.ts
+++ b/demos/Demo.ts
@@ -4,7 +4,6 @@ import { State, PostMessageRpcClient } from '@nimiq/rpc';
 import AccountsClient from '../client/AccountsClient';
 import { RequestType } from '../src/lib/RequestTypes';
 import {
-    BasicRequest,
     SimpleRequest,
     Account,
     CheckoutRequest,
@@ -16,6 +15,7 @@ import {
 import { WalletInfoEntry } from '../src/lib/WalletInfo';
 import { RedirectRequestBehavior } from '../client/RequestBehavior';
 import { Utf8Tools } from '@nimiq/utils';
+import { CookieDecoder } from '../src/lib/CookieDecoder';
 
 class Demo {
     public static run() {
@@ -414,6 +414,18 @@ class Demo {
                                 <label>
                                     <input type="radio" name="sign-tx-address" data-address="${addr}" data-wallet-id="${wallet.id}">
                                     ${acc.label}
+                                    <button class="rename" data-wallet-id="${wallet.id}" data-address="${addr}">Rename</button>
+                                </label>
+                            </li>
+                `;
+            });
+            wallet.contracts.forEach((con) => {
+                const addr = CookieDecoder.toUserFriendlyAddress(con.address);
+                html += `
+                            <li>
+                                <label>
+                                    <input type="radio" name="sign-tx-address" data-address="${addr}" data-wallet-id="${wallet.id}">
+                                    <strong>Contract</strong> ${con.label}
                                     <button class="rename" data-wallet-id="${wallet.id}" data-address="${addr}">Rename</button>
                                 </label>
                             </li>

--- a/demos/Demo.ts
+++ b/demos/Demo.ts
@@ -15,7 +15,7 @@ import {
 import { WalletInfoEntry } from '../src/lib/WalletInfo';
 import { RedirectRequestBehavior } from '../client/RequestBehavior';
 import { Utf8Tools } from '@nimiq/utils';
-import { CookieDecoder } from '../src/lib/CookieDecoder';
+import AddressUtils from '../src/lib/AddressUtils';
 
 class Demo {
     public static run() {
@@ -420,7 +420,7 @@ class Demo {
                 `;
             });
             wallet.contracts.forEach((con) => {
-                const addr = CookieDecoder.toUserFriendlyAddress(con.address);
+                const addr = AddressUtils.toUserFriendlyAddress(con.address);
                 html += `
                             <li>
                                 <label>

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "@nimiq/rpc": "^0.1.4",
         "@nimiq/style": "^0.4.1",
         "@nimiq/utils": "^0.3.0",
-        "@nimiq/vue-components": "https://github.com/nimiq/vue-components.git#build/accounts-soeren-contracts",
+        "@nimiq/vue-components": "https://github.com/nimiq/vue-components.git#build/accounts",
         "vue": "^2.6.6",
         "vue-class-component": "^6.0.0",
         "vue-property-decorator": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "@nimiq/rpc": "^0.1.4",
         "@nimiq/style": "^0.4.1",
         "@nimiq/utils": "^0.3.0",
-        "@nimiq/vue-components": "https://github.com/nimiq/vue-components.git#build/accounts",
+        "@nimiq/vue-components": "https://github.com/nimiq/vue-components.git#build/accounts-soeren-contracts",
         "vue": "^2.6.6",
         "vue-class-component": "^6.0.0",
         "vue-property-decorator": "^7.0.0",

--- a/src/components/Network.vue
+++ b/src/components/Network.vue
@@ -49,8 +49,8 @@ class Network extends Vue {
 
         if (
             (keyguardRequest.data && keyguardRequest.data.length > 0)
-            || keyguardRequest.senderType !== Nimiq.Account.Type.BASIC
-            || keyguardRequest.recipientType !== Nimiq.Account.Type.BASIC
+            || keyguardRequest.senderType // this condition is truthy when type is 1 or 2
+            || keyguardRequest.recipientType // this condition is truthy when type is 1 or 2
         ) {
             tx = new Nimiq.ExtendedTransaction(
                 new Nimiq.Address(new Nimiq.SerialBuffer(keyguardRequest.sender)),

--- a/src/components/Network.vue
+++ b/src/components/Network.vue
@@ -157,9 +157,9 @@ class Network extends Vue {
             Nimiq.Address.fromUserFriendlyAddress(contract.address),
             Nimiq.Address.fromUserFriendlyAddress(contract.owner),
             contract.start,
-            contract.stepAmount,
+            Nimiq.Policy.coinsToSatoshis(contract.stepAmount),
             contract.stepBlocks,
-            contract.totalAmount,
+            Nimiq.Policy.coinsToSatoshis(contract.totalAmount),
         ));
     }
 

--- a/src/lib/AccountInfo.ts
+++ b/src/lib/AccountInfo.ts
@@ -1,3 +1,5 @@
+import { Address } from './PublicRequestTypes';
+
 export class AccountInfo {
     public static fromObject(o: AccountInfoEntry): AccountInfo {
         return new AccountInfo(
@@ -27,6 +29,13 @@ export class AccountInfo {
             label: this.label,
             address: new Uint8Array(this.address.serialize()),
             balance: this.balance,
+        };
+    }
+
+    public toAddressType(): Address {
+        return {
+            address: this.userFriendlyAddress,
+            label: this.label,
         };
     }
 }

--- a/src/lib/AddressUtils.ts
+++ b/src/lib/AddressUtils.ts
@@ -1,3 +1,5 @@
+// tslint:disable no-bitwise
+
 export default class AddressUtils {
     // The following methods are taken from @nimiq/core source,
     // namely Nimiq.Address and Nimiq.BufferUtils.

--- a/src/lib/AddressUtils.ts
+++ b/src/lib/AddressUtils.ts
@@ -1,0 +1,62 @@
+export default class AddressUtils {
+    // The following methods are taken from @nimiq/core source,
+    // namely Nimiq.Address and Nimiq.BufferUtils.
+
+    public static toUserFriendlyAddress(serializedAddress: Uint8Array, withSpaces = true): string {
+        const base32 = this._toBase32(serializedAddress);
+        // tslint:disable-next-line prefer-template
+        const check = ('00' + (98 - this._ibanCheck(base32 + this.CCODE + '00'))).slice(-2);
+        let res = this.CCODE + check + base32;
+        if (withSpaces) res = res.replace(/.{4}/g, '$& ').trim();
+        return res;
+    }
+
+    private static CCODE = 'NQ';
+    private static BASE32_ALPHABET_NIMIQ = '0123456789ABCDEFGHJKLMNPQRSTUVXY';
+
+    private static _ibanCheck(str: string): number {
+        const num = str.split('').map((c) => {
+            const code = c.toUpperCase().charCodeAt(0);
+            return code >= 48 && code <= 57 ? c : (code - 55).toString();
+        }).join('');
+        let tmp = '';
+
+        for (let i = 0; i < Math.ceil(num.length / 6); i++) {
+            tmp = (parseInt(tmp + num.substr(i * 6, 6), 10) % 97).toString();
+        }
+
+        return parseInt(tmp, 10);
+    }
+
+    private static _toBase32(buf: Uint8Array, alphabet = this.BASE32_ALPHABET_NIMIQ): string {
+        let shift = 3;
+        let carry = 0;
+        let symbol: number;
+        let res = '';
+
+        for (const byte of buf) {
+            symbol = carry | (byte >> shift);
+            res += alphabet[symbol & 0x1f];
+
+            if (shift > 5) {
+                shift -= 5;
+                symbol = byte >> shift;
+                res += alphabet[symbol & 0x1f];
+            }
+
+            shift = 5 - shift;
+            carry = byte << shift;
+            shift = 8 - shift;
+        }
+
+        if (shift !== 3) {
+            res += alphabet[carry & 0x1f];
+        }
+
+        while (res.length % 8 !== 0 && alphabet.length === 33) {
+            res += alphabet[32];
+        }
+
+        return res;
+    }
+}

--- a/src/lib/Constants.ts
+++ b/src/lib/Constants.ts
@@ -19,6 +19,10 @@ export const ACCOUNT_DEFAULT_LABEL_LEGACY = 'Legacy Account';
 export const ACCOUNT_TEMPORARY_LABEL_KEYGUARD = '~~TEMP~~';
 export const ACCOUNT_MAX_ALLOWED_ADDRESS_GAP = 20;
 
+// Contracts
+export const CONTRACT_DEFAULT_LABEL_VESTING = 'Vesting Contract';
+export const CONTRACT_DEFAULT_LABEL_HTLC = 'HTLC';
+
 // Compatibility
 export const LEGACY_GROUPING_ACCOUNT_ID = 'LEGACY';
 export const LEGACY_GROUPING_ACCOUNT_LABEL = 'Single Accounts';

--- a/src/lib/ContractInfo.ts
+++ b/src/lib/ContractInfo.ts
@@ -11,10 +11,13 @@ export abstract class ContractInfo {
         }
     }
 
+    public walletId?: string;
+
     constructor(
         public type: Nimiq.Account.Type,
         public label: string,
         public address: Nimiq.Address,
+        public balance?: number,
     ) {}
 
     public get userFriendlyAddress(): string {
@@ -50,7 +53,7 @@ export class VestingContractInfo extends ContractInfo {
         public totalAmount: number,
         public balance?: number,
     ) {
-        super(Nimiq.Account.Type.VESTING, label, address);
+        super(Nimiq.Account.Type.VESTING, label, address, balance);
     }
 
     public toObject(): VestingContractInfoEntry {
@@ -78,6 +81,14 @@ export class VestingContractInfo extends ContractInfo {
             stepBlocks: this.stepBlocks,
             totalAmount: this.totalAmount,
         };
+    }
+
+    public calculateAvailableAmount(height: number, currentBalance = this.totalAmount) {
+        return (currentBalance - this.totalAmount)
+        + Math.min(
+            this.totalAmount,
+            Math.max(0, Math.floor((height - this.start) / this.stepBlocks)) * this.stepAmount,
+        );
     }
 }
 
@@ -107,7 +118,7 @@ export class HashedTimeLockedContractInfo extends ContractInfo {
         public totalAmount: number,
         public balance?: number,
     ) {
-        super(Nimiq.Account.Type.HTLC, label, address);
+        super(Nimiq.Account.Type.HTLC, label, address, balance);
     }
 
     public toObject(): HashedTimeLockedContractInfoEntry {

--- a/src/lib/ContractInfo.ts
+++ b/src/lib/ContractInfo.ts
@@ -1,35 +1,19 @@
 import { VestingContract, HashedTimeLockedContract, Contract } from './PublicRequestTypes';
 
-export abstract class ContractInfo {
+export class ContractInfoHelper {
     public static fromObject(o: ContractInfoEntry): VestingContractInfo | HashedTimeLockedContractInfo {
         switch (o.type) {
             case Nimiq.Account.Type.VESTING:
-                return VestingContractInfo.fromObject(o as VestingContractInfoEntry);
+                return VestingContractInfo.fromObject(o);
             case Nimiq.Account.Type.HTLC:
-                return HashedTimeLockedContractInfo.fromObject(o as HashedTimeLockedContractInfoEntry);
+                return HashedTimeLockedContractInfo.fromObject(o);
+            // @ts-ignore Property 'type' does not exist on type 'never'
             default: throw new Error('Unknown contract type: ' + o.type);
         }
     }
-
-    public walletId?: string;
-
-    constructor(
-        public type: Nimiq.Account.Type,
-        public label: string,
-        public address: Nimiq.Address,
-        public balance?: number,
-    ) {}
-
-    public get userFriendlyAddress(): string {
-        return this.address.toUserFriendlyAddress();
-    }
-
-    public abstract toObject(): ContractInfoEntry;
-
-    public abstract toContractType(): Contract;
 }
 
-export class VestingContractInfo extends ContractInfo {
+export class VestingContractInfo {
     public static fromObject(o: VestingContractInfoEntry): VestingContractInfo {
         return new VestingContractInfo(
             o.label,
@@ -43,6 +27,9 @@ export class VestingContractInfo extends ContractInfo {
         );
     }
 
+    public type = Nimiq.Account.Type.VESTING;
+    public walletId?: string;
+
     public constructor(
         public label: string,
         public address: Nimiq.Address,
@@ -52,8 +39,10 @@ export class VestingContractInfo extends ContractInfo {
         public stepBlocks: number,
         public totalAmount: number,
         public balance?: number,
-    ) {
-        super(Nimiq.Account.Type.VESTING, label, address, balance);
+    ) {}
+
+    public get userFriendlyAddress(): string {
+        return this.address.toUserFriendlyAddress();
     }
 
     public toObject(): VestingContractInfoEntry {
@@ -72,7 +61,7 @@ export class VestingContractInfo extends ContractInfo {
 
     public toContractType(): VestingContract {
         return {
-            type: Nimiq.Account.Type.VESTING,
+            type: this.type,
             label: this.label,
             address: this.userFriendlyAddress,
             owner: this.owner.toUserFriendlyAddress(),
@@ -92,7 +81,7 @@ export class VestingContractInfo extends ContractInfo {
     }
 }
 
-export class HashedTimeLockedContractInfo extends ContractInfo {
+export class HashedTimeLockedContractInfo {
     public static fromObject(o: HashedTimeLockedContractInfoEntry): HashedTimeLockedContractInfo {
         return new HashedTimeLockedContractInfo(
             o.label,
@@ -107,6 +96,9 @@ export class HashedTimeLockedContractInfo extends ContractInfo {
         );
     }
 
+    public type = Nimiq.Account.Type.HTLC;
+    public walletId?: string;
+
     public constructor(
         public label: string,
         public address: Nimiq.Address,
@@ -117,8 +109,10 @@ export class HashedTimeLockedContractInfo extends ContractInfo {
         public timeout: number,
         public totalAmount: number,
         public balance?: number,
-    ) {
-        super(Nimiq.Account.Type.HTLC, label, address, balance);
+    ) {}
+
+    public get userFriendlyAddress(): string {
+        return this.address.toUserFriendlyAddress();
     }
 
     public toObject(): HashedTimeLockedContractInfoEntry {
@@ -138,7 +132,7 @@ export class HashedTimeLockedContractInfo extends ContractInfo {
 
     public toContractType(): HashedTimeLockedContract {
         return {
-            type: Nimiq.Account.Type.VESTING,
+            type: Nimiq.Account.Type.HTLC,
             label: this.label,
             address: this.userFriendlyAddress,
             sender: this.sender.toUserFriendlyAddress(),
@@ -151,11 +145,13 @@ export class HashedTimeLockedContractInfo extends ContractInfo {
     }
 }
 
+export type ContractInfo = VestingContractInfo | HashedTimeLockedContractInfo;
+
 /*
  * Database Types
  */
 export interface VestingContractInfoEntry {
-    type: Nimiq.Account.Type;
+    type: Nimiq.Account.Type.VESTING;
     label: string;
     address: Uint8Array;
     owner: Uint8Array;
@@ -167,7 +163,7 @@ export interface VestingContractInfoEntry {
 }
 
 export interface HashedTimeLockedContractInfoEntry {
-    type: Nimiq.Account.Type;
+    type: Nimiq.Account.Type.HTLC;
     label: string;
     address: Uint8Array;
     sender: Uint8Array;

--- a/src/lib/ContractInfo.ts
+++ b/src/lib/ContractInfo.ts
@@ -72,12 +72,43 @@ export class VestingContractInfo {
         };
     }
 
+    /**
+     * Calculates the available amount of a vesting contract for a given blockchain height
+     *
+     * First, an explanation of the parameters of a vesting contract:
+     * totalAmount: The total value of a vesting contract (fixed during creation, cannot be changed).
+     * stepAmount: How much value is released at every vesting step. The total amount does not have
+     *             to devide evenly through this amount. The last vesting step amount can be smaller
+     *             then the previous steps.
+     * stepBlocks: The number of blocks between step amount releases.
+     * start: The block height at which the first step starts to count.
+     *
+     * To calculate the amount available, we start by dividing the number of blocks passed since
+     * the contract's start height through its stepBlocks, to determine how many vesting steps have
+     * passed. The floored number of steps gets muliplied by the stepAmount to calculate all so far
+     * released value:
+     *      Math.floor((height - this.start) / this.stepBlocks)) * this.stepAmount
+     *
+     * Because the vested amount cannot be negative (in case start block height is higher than the
+     * blockchain height), the above calculation is set to at least 0:
+     *      Math.max(0, <previous result>)
+     *
+     * Because the last step of a vesting contract is always the remainder and can be smaller than
+     * stepAmount, we safeguard the maximum possible released value by taking the smaller of
+     * the above calculated released amount and the contract's totalAmount:
+     *      Math.min(this.totalAmount, <previous result>)
+     *
+     * Finally, the available amount needs to account for already withrawn funds. (The balance
+     * reported by the network represents the balance of the contract, including not-yet-released
+     * funds.) The amount already withdrawn is the difference between the totalAmount (inital balance)
+     * and currentBalance. The withdrawn amount is simply subtracted from the released amount:
+     *      <previous result> - (this.totalAmount - currentBalance)
+     */
     public calculateAvailableAmount(height: number, currentBalance = this.totalAmount) {
-        return (currentBalance - this.totalAmount)
-        + Math.min(
+        return Math.min(
             this.totalAmount,
             Math.max(0, Math.floor((height - this.start) / this.stepBlocks)) * this.stepAmount,
-        );
+        ) - (this.totalAmount - currentBalance);
     }
 }
 

--- a/src/lib/ContractInfo.ts
+++ b/src/lib/ContractInfo.ts
@@ -1,11 +1,158 @@
+import { VestingContract, HashedTimeLockedContract } from './PublicRequestTypes';
+
 export enum ContractType {
     VESTING,
     HTLC,
 }
 
-export interface ContractInfo {
-    address: Nimiq.Address;
-    label: string;
-    ownerPath: string;
+export type ContractInfo = VestingContractInfo | HashedTimeLockedContractInfo;
+
+export class VestingContractInfo {
+    public static fromObject(o: VestingContractInfoEntry): VestingContractInfo {
+        return new VestingContractInfo(
+            o.label,
+            new Nimiq.Address(new Nimiq.SerialBuffer(o.address)),
+            new Nimiq.Address(new Nimiq.SerialBuffer(o.owner)),
+            o.start,
+            o.stepAmount,
+            o.stepBlocks,
+            o.totalAmount,
+            o.balance,
+        );
+    }
+
+    public readonly type: ContractType = ContractType.VESTING;
+
+    public constructor(
+        public label: string,
+        public address: Nimiq.Address,
+        public owner: Nimiq.Address,
+        public start: number,
+        public stepAmount: number,
+        public stepBlocks: number,
+        public totalAmount: number,
+        public balance?: number,
+    ) {}
+
+    public get userFriendlyAddress(): string {
+        return this.address.toUserFriendlyAddress();
+    }
+
+    public toObject(): VestingContractInfoEntry {
+        return {
+            type: this.type,
+            label: this.label,
+            address: this.address.serialize(),
+            owner: this.owner.serialize(),
+            start: this.start,
+            stepAmount: this.stepAmount,
+            stepBlocks: this.stepBlocks,
+            totalAmount: this.totalAmount,
+            balance: this.balance,
+        };
+    }
+
+    public toContractType(): VestingContract {
+        return {
+            type: ContractType.VESTING,
+            address: this.userFriendlyAddress,
+            label: this.label,
+            owner: this.owner.toUserFriendlyAddress(),
+            start: this.start,
+            stepAmount: this.stepAmount,
+            stepBlocks: this.stepBlocks,
+            totalAmount: this.totalAmount,
+        };
+    }
+}
+
+export class HashedTimeLockedContractInfo {
+    public static fromObject(o: HashedTimeLockedContractInfoEntry): HashedTimeLockedContractInfo {
+        return new HashedTimeLockedContractInfo(
+            o.label,
+            new Nimiq.Address(new Nimiq.SerialBuffer(o.address)),
+            new Nimiq.Address(new Nimiq.SerialBuffer(o.sender)),
+            new Nimiq.Address(new Nimiq.SerialBuffer(o.recipient)),
+            new Nimiq.Hash(new Nimiq.SerialBuffer(o.hashRoot)),
+            o.hashCount,
+            o.timeout,
+            o.totalAmount,
+            o.balance,
+        );
+    }
+
+    public readonly type: ContractType = ContractType.HTLC;
+
+    public constructor(
+        public label: string,
+        public address: Nimiq.Address,
+        public sender: Nimiq.Address,
+        public recipient: Nimiq.Address,
+        public hashRoot: Nimiq.Hash,
+        public hashCount: number,
+        public timeout: number,
+        public totalAmount: number,
+        public balance?: number,
+    ) {}
+
+    public get userFriendlyAddress(): string {
+        return this.address.toUserFriendlyAddress();
+    }
+
+    public toObject(): HashedTimeLockedContractInfoEntry {
+        return {
+            type: this.type,
+            label: this.label,
+            address: this.address.serialize(),
+            sender: this.sender.serialize(),
+            recipient: this.recipient.serialize(),
+            hashRoot: this.hashRoot.serialize(),
+            hashCount: this.hashCount,
+            timeout: this.timeout,
+            totalAmount: this.totalAmount,
+            balance: this.balance,
+        };
+    }
+
+    public toContractType(): HashedTimeLockedContract {
+        return {
+            type: ContractType.VESTING,
+            address: this.userFriendlyAddress,
+            label: this.label,
+            sender: this.sender.toUserFriendlyAddress(),
+            recipient: this.recipient.toUserFriendlyAddress(),
+            hashRoot: this.hashRoot.toHex(),
+            hashCount: this.hashCount,
+            timeout: this.timeout,
+            totalAmount: this.totalAmount,
+        };
+    }
+}
+
+/*
+ * Database Types
+ */
+export interface VestingContractInfoEntry {
     type: ContractType;
+    label: string;
+    address: Uint8Array;
+    owner: Uint8Array;
+    start: number;
+    stepAmount: number;
+    stepBlocks: number;
+    totalAmount: number;
+    balance?: number;
+}
+
+export interface HashedTimeLockedContractInfoEntry {
+    type: ContractType;
+    label: string;
+    address: Uint8Array;
+    sender: Uint8Array;
+    recipient: Uint8Array;
+    hashRoot: Uint8Array;
+    hashCount: number;
+    timeout: number;
+    totalAmount: number;
+    balance?: number;
 }

--- a/src/lib/ContractInfo.ts
+++ b/src/lib/ContractInfo.ts
@@ -1,23 +1,18 @@
 import { VestingContract, HashedTimeLockedContract, Contract } from './PublicRequestTypes';
 
-export enum ContractType {
-    VESTING,
-    HTLC,
-}
-
 export abstract class ContractInfo {
     public static fromObject(o: ContractInfoEntry): VestingContractInfo | HashedTimeLockedContractInfo {
         switch (o.type) {
-            case ContractType.VESTING:
+            case Nimiq.Account.Type.VESTING:
                 return VestingContractInfo.fromObject(o as VestingContractInfoEntry);
-            case ContractType.HTLC:
+            case Nimiq.Account.Type.HTLC:
                 return HashedTimeLockedContractInfo.fromObject(o as HashedTimeLockedContractInfoEntry);
             default: throw new Error('Unknown contract type: ' + o.type);
         }
     }
 
     constructor(
-        public type: ContractType,
+        public type: Nimiq.Account.Type,
         public label: string,
         public address: Nimiq.Address,
     ) {}
@@ -55,7 +50,7 @@ export class VestingContractInfo extends ContractInfo {
         public totalAmount: number,
         public balance?: number,
     ) {
-        super(ContractType.VESTING, label, address);
+        super(Nimiq.Account.Type.VESTING, label, address);
     }
 
     public toObject(): VestingContractInfoEntry {
@@ -74,7 +69,7 @@ export class VestingContractInfo extends ContractInfo {
 
     public toContractType(): VestingContract {
         return {
-            type: ContractType.VESTING,
+            type: Nimiq.Account.Type.VESTING,
             label: this.label,
             address: this.userFriendlyAddress,
             owner: this.owner.toUserFriendlyAddress(),
@@ -112,7 +107,7 @@ export class HashedTimeLockedContractInfo extends ContractInfo {
         public totalAmount: number,
         public balance?: number,
     ) {
-        super(ContractType.HTLC, label, address);
+        super(Nimiq.Account.Type.HTLC, label, address);
     }
 
     public toObject(): HashedTimeLockedContractInfoEntry {
@@ -132,7 +127,7 @@ export class HashedTimeLockedContractInfo extends ContractInfo {
 
     public toContractType(): HashedTimeLockedContract {
         return {
-            type: ContractType.VESTING,
+            type: Nimiq.Account.Type.VESTING,
             label: this.label,
             address: this.userFriendlyAddress,
             sender: this.sender.toUserFriendlyAddress(),
@@ -149,7 +144,7 @@ export class HashedTimeLockedContractInfo extends ContractInfo {
  * Database Types
  */
 export interface VestingContractInfoEntry {
-    type: ContractType;
+    type: Nimiq.Account.Type;
     label: string;
     address: Uint8Array;
     owner: Uint8Array;
@@ -161,7 +156,7 @@ export interface VestingContractInfoEntry {
 }
 
 export interface HashedTimeLockedContractInfoEntry {
-    type: ContractType;
+    type: Nimiq.Account.Type;
     label: string;
     address: Uint8Array;
     sender: Uint8Array;

--- a/src/lib/ContractInfo.ts
+++ b/src/lib/ContractInfo.ts
@@ -7,7 +7,7 @@ export class ContractInfoHelper {
                 return VestingContractInfo.fromObject(o);
             case Nimiq.Account.Type.HTLC:
                 return HashedTimeLockedContractInfo.fromObject(o);
-            // @ts-ignore Property 'type' does not exist on type 'never'
+            // @ts-ignore Property 'type' does not exist on type 'never'.
             default: throw new Error('Unknown contract type: ' + o.type);
         }
     }

--- a/src/lib/CookieJar.ts
+++ b/src/lib/CookieJar.ts
@@ -2,8 +2,14 @@
 
 import { WalletInfoEntry, WalletType } from './WalletInfo';
 import { Utf8Tools } from '@nimiq/utils';
-import { LABEL_MAX_LENGTH, ACCOUNT_DEFAULT_LABEL_LEDGER } from '@/lib/Constants';
+import {
+    LABEL_MAX_LENGTH,
+    ACCOUNT_DEFAULT_LABEL_LEDGER,
+    CONTRACT_DEFAULT_LABEL_VESTING,
+    CONTRACT_DEFAULT_LABEL_HTLC,
+} from '@/lib/Constants';
 import LabelingMachine from './LabelingMachine';
+import { ContractInfoEntry, VestingContractInfoEntry, VestingContractInfo } from './ContractInfo';
 
 class CookieJar {
     public static readonly VERSION = 1;
@@ -81,11 +87,19 @@ class CookieJar {
         return label;
     }
 
-    private static checkAccountDefaultLabel(address: Uint8Array, label: string) {
+    private static checkAccountDefaultLabel(address: Uint8Array, label: string): string {
         const userFriendlyAddress = new Nimiq.Address(address).toUserFriendlyAddress();
         const defaultLabel = LabelingMachine.labelAddress(userFriendlyAddress);
         if (label === defaultLabel) return '';
         return label;
+    }
+
+    private static checkContractDefaultLabel(type: Nimiq.Account.Type, label: string): string {
+        switch (type) {
+            case Nimiq.Account.Type.VESTING: return label === CONTRACT_DEFAULT_LABEL_VESTING ? '' : label;
+            case Nimiq.Account.Type.HTLC: return label === CONTRACT_DEFAULT_LABEL_HTLC ? '' : label;
+            default: return label;
+        }
     }
 
     private static encodeWallet(wallet: WalletInfoEntry) {
@@ -114,7 +128,9 @@ class CookieJar {
         statusByte = statusByte
                 | (wallet.keyMissing ? CookieJar.StatusFlags.KEY_MISSING : CookieJar.StatusFlags.NONE)
                 | (wallet.fileExported ? CookieJar.StatusFlags.FILE_EXPORTED : CookieJar.StatusFlags.NONE)
-                | (wallet.wordsExported ? CookieJar.StatusFlags.WORDS_EXPORTED : CookieJar.StatusFlags.NONE);
+                | (wallet.wordsExported ? CookieJar.StatusFlags.WORDS_EXPORTED : CookieJar.StatusFlags.NONE)
+                | (wallet.contracts.length ? CookieJar.StatusFlags.HAS_CONTRACTS : CookieJar.StatusFlags.NONE)
+        ;
         bytes.push(statusByte);
 
         // Wallet ID
@@ -132,9 +148,7 @@ class CookieJar {
         }
 
         // Label
-        if (labelBytes.length > 0) {
-            bytes.push.apply(bytes, Array.from(labelBytes));
-        }
+        bytes.push.apply(bytes, Array.from(labelBytes));
 
         // Legacy account information
         if (wallet.type === WalletType.LEGACY) {
@@ -142,6 +156,9 @@ class CookieJar {
 
             // Account address
             bytes.push.apply(bytes, Array.from(account.address));
+
+            this.encodeContracts(wallet.contracts, bytes);
+
             return bytes;
         }
 
@@ -160,15 +177,50 @@ class CookieJar {
             bytes.push(labelBytes.length);
 
             // Account label
-            if (labelBytes.length > 0) {
-                bytes.push.apply(bytes, Array.from(labelBytes));
-            }
+            bytes.push.apply(bytes, Array.from(labelBytes));
 
             // Account address
             bytes.push.apply(bytes, Array.from(account.address));
         }
 
+        this.encodeContracts(wallet.contracts, bytes);
+
         return bytes;
+    }
+
+    private static encodeContracts(contracts: ContractInfoEntry[], bytes: number[]) {
+        if (!contracts.length) return;
+
+        bytes.push(contracts.length);
+
+        for (const contract of contracts) {
+            const label = this.checkContractDefaultLabel(contract.type, contract.label);
+            const labelBytes = this.encodeAndcutLabel(label);
+
+            // Combined contract label length and type
+            bytes.push((labelBytes.length << 2) | contract.type);
+
+            // Contract label
+            bytes.push.apply(bytes, Array.from(labelBytes));
+
+            // Contract address
+            bytes.push.apply(bytes, Array.from(contract.address));
+
+            switch (contract.type) {
+                case Nimiq.Account.Type.VESTING:
+                    const data = contract as VestingContractInfoEntry;
+                    bytes.push.apply(bytes, Array.from(data.owner));
+                    bytes.push.apply(bytes, this.toBase256(data.start, 4)); // Uint32
+                    bytes.push.apply(bytes, this.toBase256(data.stepAmount, 8)); // Uint64
+                    bytes.push.apply(bytes, this.toBase256(data.stepBlocks, 4)); // Uint32
+                    bytes.push.apply(bytes, this.toBase256(data.totalAmount, 8)); // Uint64
+                    break;
+                case Nimiq.Account.Type.HTLC:
+                    throw new Error('HTLC encoding is not yet implemented');
+                default:
+                    throw new Error('Unknown contract type: ' + contract.type);
+            }
+        }
     }
 
     private static getCookieContents(): string | null {
@@ -181,8 +233,12 @@ class CookieJar {
         return Nimiq.BufferUtils.fromBase64(encodedWallets).length;
     }
 
-    private static toBase256(value: number) {
-        const bits = value.toString(2);
+    private static toBase256(value: number, padToBytes?: number) {
+        let bits = value.toString(2);
+
+        if (padToBytes) {
+            bits = bits.padStart(padToBytes * 8, '0');
+        }
 
         // Reverse so we can split into 8s from the end
         const reverseBits = bits.split('').reverse().join('');
@@ -202,6 +258,7 @@ namespace CookieJar { // tslint:disable-line no-namespace
         KEY_MISSING    = 1 << 0,
         FILE_EXPORTED  = 1 << 1,
         WORDS_EXPORTED = 1 << 2,
+        HAS_CONTRACTS  = 1 << 3,
     }
 }
 

--- a/src/lib/CookieJar.ts
+++ b/src/lib/CookieJar.ts
@@ -218,6 +218,7 @@ class CookieJar {
                 case Nimiq.Account.Type.HTLC:
                     throw new Error('HTLC encoding is not yet implemented');
                 default:
+                    // @ts-ignore Property 'type' does not exist on type 'never'.
                     throw new Error('Unknown contract type: ' + contract.type);
             }
         }

--- a/src/lib/PublicRequestTypes.ts
+++ b/src/lib/PublicRequestTypes.ts
@@ -1,5 +1,4 @@
 import { WalletType, WalletInfoEntry } from './WalletInfo';
-import { ContractType } from './ContractInfo';
 
 export interface BasicRequest {
     appName: string;
@@ -77,7 +76,7 @@ export interface Address {
 }
 
 export interface VestingContract {
-    type: ContractType;
+    type: Nimiq.Account.Type;
     address: string; // Userfriendly address
     label: string;
 
@@ -89,7 +88,7 @@ export interface VestingContract {
 }
 
 export interface HashedTimeLockedContract {
-    type: ContractType;
+    type: Nimiq.Account.Type;
     address: string; // Userfriendly address
     label: string;
 

--- a/src/lib/PublicRequestTypes.ts
+++ b/src/lib/PublicRequestTypes.ts
@@ -76,7 +76,7 @@ export interface Address {
 }
 
 export interface VestingContract {
-    type: Nimiq.Account.Type;
+    type: Nimiq.Account.Type.VESTING;
     address: string; // Userfriendly address
     label: string;
 
@@ -88,7 +88,7 @@ export interface VestingContract {
 }
 
 export interface HashedTimeLockedContract {
-    type: Nimiq.Account.Type;
+    type: Nimiq.Account.Type.HTLC;
     address: string; // Userfriendly address
     label: string;
 

--- a/src/lib/PublicRequestTypes.ts
+++ b/src/lib/PublicRequestTypes.ts
@@ -1,4 +1,5 @@
 import { WalletType, WalletInfoEntry } from './WalletInfo';
+import { ContractType } from './ContractInfo';
 
 export interface BasicRequest {
     appName: string;
@@ -75,6 +76,33 @@ export interface Address {
     label: string;
 }
 
+export interface VestingContract {
+    type: ContractType;
+    address: string; // Userfriendly address
+    label: string;
+
+    owner: string; // Userfriendly address
+    start: number;
+    stepAmount: number;
+    stepBlocks: number;
+    totalAmount: number;
+}
+
+export interface HashedTimeLockedContract {
+    type: ContractType;
+    address: string; // Userfriendly address
+    label: string;
+
+    sender: string;  // Userfriendly address
+    recipient: string;  // Userfriendly address
+    hashRoot: string; // HEX
+    hashCount: number;
+    timeout: number;
+    totalAmount: number;
+}
+
+export type Contract = VestingContract | HashedTimeLockedContract;
+
 export interface Account {
     accountId: string;
     label: string;
@@ -82,6 +110,7 @@ export interface Account {
     fileExported: boolean;
     wordsExported: boolean;
     addresses: Address[];
+    contracts: Contract[];
 }
 
 export interface ExportResult {

--- a/src/lib/WalletInfo.ts
+++ b/src/lib/WalletInfo.ts
@@ -48,6 +48,17 @@ export class WalletInfo {
         });
     }
 
+    public setContract(updatedContract: ContractInfo) {
+        const index = this.contracts.findIndex((contract) => contract.address.equals(updatedContract.address));
+        if (index < 0) {
+            // Is new contract
+            this.contracts.push(updatedContract);
+            return;
+        }
+
+        this.contracts.splice(index, 1, updatedContract);
+    }
+
     public toObject(): WalletInfoEntry {
         const accountEntries = new Map<string, AccountInfoEntry>();
         this.accounts.forEach((accountInfo, userFriendlyAddress) => {

--- a/src/lib/WalletInfo.ts
+++ b/src/lib/WalletInfo.ts
@@ -1,9 +1,8 @@
 import { AccountInfo, AccountInfoEntry } from './AccountInfo';
 import {
     ContractInfo,
-    VestingContractInfo,
-    HashedTimeLockedContractInfo,
     ContractInfoEntry,
+    ContractInfoHelper,
 } from './ContractInfo';
 
 export enum WalletType {
@@ -18,7 +17,7 @@ export class WalletInfo {
         o.accounts.forEach((accountInfoEntry, userFriendlyAddress) => {
             accounts.set(userFriendlyAddress, AccountInfo.fromObject(accountInfoEntry));
         });
-        const contracts = o.contracts.map((contract) => ContractInfo.fromObject(contract));
+        const contracts = o.contracts.map((contract) => ContractInfoHelper.fromObject(contract));
         return new WalletInfo(o.id, o.label, accounts, contracts, o.type,
             o.keyMissing, o.fileExported, o.wordsExported);
     }
@@ -39,10 +38,10 @@ export class WalletInfo {
     public findContractsByOwner(address: Nimiq.Address): ContractInfo[] {
         return this.contracts.filter((contract) => {
             switch (contract.type) {
-                case Nimiq.Account.Type.VESTING: return (contract as VestingContractInfo).owner.equals(address);
+                case Nimiq.Account.Type.VESTING: return contract.owner.equals(address);
                 case Nimiq.Account.Type.HTLC:
-                    return (contract as HashedTimeLockedContractInfo).sender.equals(address)
-                        || (contract as HashedTimeLockedContractInfo).recipient.equals(address);
+                    return contract.sender.equals(address)
+                        || contract.recipient.equals(address);
                 default: return false;
             }
         });

--- a/src/lib/WalletInfo.ts
+++ b/src/lib/WalletInfo.ts
@@ -1,7 +1,6 @@
 import { AccountInfo, AccountInfoEntry } from './AccountInfo';
 import {
     ContractInfo,
-    ContractType,
     VestingContractInfo,
     HashedTimeLockedContractInfo,
     ContractInfoEntry,
@@ -40,8 +39,8 @@ export class WalletInfo {
     public findContractsByOwner(address: Nimiq.Address): ContractInfo[] {
         return this.contracts.filter((contract) => {
             switch (contract.type) {
-                case ContractType.VESTING: return (contract as VestingContractInfo).owner.equals(address);
-                case ContractType.HTLC:
+                case Nimiq.Account.Type.VESTING: return (contract as VestingContractInfo).owner.equals(address);
+                case Nimiq.Account.Type.HTLC:
                     return (contract as HashedTimeLockedContractInfo).sender.equals(address)
                         || (contract as HashedTimeLockedContractInfo).recipient.equals(address);
                 default: return false;

--- a/src/lib/WalletInfo.ts
+++ b/src/lib/WalletInfo.ts
@@ -1,5 +1,11 @@
 import { AccountInfo, AccountInfoEntry } from './AccountInfo';
-import { ContractInfo, ContractType, VestingContractInfo, HashedTimeLockedContractInfo } from './ContractInfo';
+import {
+    ContractInfo,
+    ContractType,
+    VestingContractInfo,
+    HashedTimeLockedContractInfo,
+    ContractInfoEntry,
+} from './ContractInfo';
 
 export enum WalletType {
     LEGACY = 1,
@@ -13,7 +19,8 @@ export class WalletInfo {
         o.accounts.forEach((accountInfoEntry, userFriendlyAddress) => {
             accounts.set(userFriendlyAddress, AccountInfo.fromObject(accountInfoEntry));
         });
-        return new WalletInfo(o.id, o.label, accounts, o.contracts, o.type,
+        const contracts = o.contracts.map((contract) => ContractInfo.fromObject(contract));
+        return new WalletInfo(o.id, o.label, accounts, contracts, o.type,
             o.keyMissing, o.fileExported, o.wordsExported);
     }
 
@@ -47,11 +54,12 @@ export class WalletInfo {
         this.accounts.forEach((accountInfo, userFriendlyAddress) => {
             accountEntries.set(userFriendlyAddress, accountInfo.toObject());
         });
+        const contractEntries = this.contracts.map((contract) => contract.toObject());
         return {
             id: this.id,
             label: this.label,
             accounts: accountEntries,
-            contracts: this.contracts,
+            contracts: contractEntries,
             type: this.type,
             keyMissing: this.keyMissing,
             fileExported: this.fileExported,
@@ -67,7 +75,7 @@ export interface WalletInfoEntry {
     id: string;
     label: string;
     accounts: Map</*address*/ string, AccountInfoEntry>;
-    contracts: ContractInfo[];
+    contracts: ContractInfoEntry[];
     type: WalletType;
     keyMissing: boolean;
     fileExported: boolean;

--- a/src/lib/WalletInfo.ts
+++ b/src/lib/WalletInfo.ts
@@ -1,5 +1,5 @@
 import { AccountInfo, AccountInfoEntry } from './AccountInfo';
-import { ContractInfo } from './ContractInfo';
+import { ContractInfo, ContractType, VestingContractInfo, HashedTimeLockedContractInfo } from './ContractInfo';
 
 export enum WalletType {
     LEGACY = 1,
@@ -25,6 +25,22 @@ export class WalletInfo {
                        public keyMissing: boolean = false,
                        public fileExported: boolean = false,
                        public wordsExported: boolean = false) {}
+
+    public findContractByAddress(address: Nimiq.Address): ContractInfo | undefined {
+        return this.contracts.find((contract) => contract.address.equals(address));
+    }
+
+    public findContractsByOwner(address: Nimiq.Address): ContractInfo[] {
+        return this.contracts.filter((contract) => {
+            switch (contract.type) {
+                case ContractType.VESTING: return (contract as VestingContractInfo).owner.equals(address);
+                case ContractType.HTLC:
+                    return (contract as HashedTimeLockedContractInfo).sender.equals(address)
+                        || (contract as HashedTimeLockedContractInfo).recipient.equals(address);
+                default: return false;
+            }
+        });
+    }
 
     public toObject(): WalletInfoEntry {
         const accountEntries = new Map<string, AccountInfoEntry>();

--- a/src/lib/WalletInfoCollector.ts
+++ b/src/lib/WalletInfoCollector.ts
@@ -275,9 +275,9 @@ export default class WalletInfoCollector {
             Nimiq.Address.fromUserFriendlyAddress(contract.address),
             Nimiq.Address.fromUserFriendlyAddress(contract.owner),
             contract.start,
-            contract.stepAmount,
+            Nimiq.Policy.coinsToSatoshis(contract.stepAmount),
             contract.stepBlocks,
-            contract.totalAmount,
+            Nimiq.Policy.coinsToSatoshis(contract.totalAmount),
         ));
     }
 }

--- a/src/lib/WalletInfoCollector.ts
+++ b/src/lib/WalletInfoCollector.ts
@@ -142,7 +142,8 @@ export default class WalletInfoCollector {
 
     private static _initializeDependencies(walletType: WalletType): void {
         WalletInfoCollector._networkInitializationPromise =
-            WalletInfoCollector._networkInitializationPromise || NetworkClient.Instance.init();
+            WalletInfoCollector._networkInitializationPromise
+            || NetworkClient.createInstance(Config.networkEndpoint).init();
         WalletInfoCollector._networkInitializationPromise
             .catch(() => delete WalletInfoCollector._networkInitializationPromise);
         if (walletType === WalletType.BIP39) {
@@ -265,6 +266,7 @@ export default class WalletInfoCollector {
     }
 
     private static async _getGenesisVestingContracts(): Promise<VestingContractInfo[]> {
+        await WalletInfoCollector._networkInitializationPromise;
         const contracts = await NetworkClient.Instance.getGenesisVestingContracts();
 
         return contracts.map((contract) => new VestingContractInfo(

--- a/src/lib/WalletInfoCollector.ts
+++ b/src/lib/WalletInfoCollector.ts
@@ -7,6 +7,7 @@ import LedgerApi from '@/lib/LedgerApi'; // TODO import LedgerApi only when need
 import {
     ACCOUNT_DEFAULT_LABEL_LEGACY,
     ACCOUNT_DEFAULT_LABEL_LEDGER,
+    CONTRACT_DEFAULT_LABEL_VESTING,
     ACCOUNT_TEMPORARY_LABEL_KEYGUARD,
     ACCOUNT_MAX_ALLOWED_ADDRESS_GAP,
     ACCOUNT_BIP32_BASE_PATH_KEYGUARD,
@@ -270,7 +271,7 @@ export default class WalletInfoCollector {
         const contracts = await NetworkClient.Instance.getGenesisVestingContracts();
 
         return contracts.map((contract) => new VestingContractInfo(
-            'Vesting Contract',
+            CONTRACT_DEFAULT_LABEL_VESTING,
             Nimiq.Address.fromUserFriendlyAddress(contract.address),
             Nimiq.Address.fromUserFriendlyAddress(contract.owner),
             contract.start,

--- a/src/store.ts
+++ b/src/store.ts
@@ -8,6 +8,7 @@ import {
     LEGACY_GROUPING_ACCOUNT_ID,
     LEGACY_GROUPING_ACCOUNT_LABEL,
 } from '@/lib/Constants';
+import { ContractInfo } from './lib/ContractInfo';
 
 Vue.use(Vuex);
 
@@ -124,6 +125,7 @@ const store: StoreOptions<RootState> = {
         },
         processedWallets: (state) => {
             const singleAccounts = new Map<string, AccountInfo>();
+            const singleContracts: ContractInfo[] = [];
 
             const processedWallets = state.wallets.filter((wallet) => {
                 if (wallet.type !== WalletType.LEGACY) return true;
@@ -131,6 +133,11 @@ const store: StoreOptions<RootState> = {
                 const [singleAccountAddress, singleAccountInfo] = Array.from(wallet.accounts.entries())[0];
                 singleAccountInfo.walletId = wallet.id;
                 singleAccounts.set(singleAccountAddress, singleAccountInfo);
+
+                for (const contract of wallet.contracts) {
+                    contract.walletId = wallet.id;
+                    singleContracts.push(contract);
+                }
 
                 return false;
             });
@@ -140,7 +147,7 @@ const store: StoreOptions<RootState> = {
                     LEGACY_GROUPING_ACCOUNT_ID,
                     LEGACY_GROUPING_ACCOUNT_LABEL,
                     singleAccounts,
-                    [],
+                    singleContracts,
                     WalletType.LEGACY,
                 ));
             }

--- a/src/views/Checkout.vue
+++ b/src/views/Checkout.vue
@@ -26,7 +26,7 @@
             <AccountSelector
                 :wallets="processedWallets"
                 :minBalance="request.value + request.fee"
-                @account-selected="accountSelected"
+                @account-selected="accountOrContractSelected"
                 @login="goToOnboarding"/>
 
             <AccountInfoScreen
@@ -131,10 +131,9 @@ export default class Checkout extends Vue {
                     // Calculate available amount for vesting contract
                     accountOrContract.balance = accountOrContract
                         .calculateAvailableAmount(this.height, Nimiq.Policy.coinsToSatoshis(balance));
-                    continue;
+                } else {
+                    accountOrContract.balance = Nimiq.Policy.coinsToSatoshis(balance);
                 }
-
-                accountOrContract.balance = Nimiq.Policy.coinsToSatoshis(balance);
             }
 
             // Store updated wallets
@@ -162,7 +161,7 @@ export default class Checkout extends Vue {
         this.height = head.height;
     }
 
-    private accountSelected(walletId: string, address: string) {
+    private accountOrContractSelected(walletId: string, address: string) {
         if (!this.height) return; // TODO: Make it impossible for users to click when height is not ready
 
         const walletInfo = this.wallets.find((wallet: WalletInfo) => wallet.id === walletId)!;

--- a/src/views/Checkout.vue
+++ b/src/views/Checkout.vue
@@ -129,8 +129,8 @@ export default class Checkout extends Vue {
 
                 if ('type' in accountOrContract && accountOrContract.type === Nimiq.Account.Type.VESTING) {
                     // Calculate available amount for vesting contract
-                    accountOrContract.balance =
-                        (accountOrContract as VestingContractInfo).calculateAvailableAmount(this.height, balance);
+                    accountOrContract.balance = (accountOrContract as VestingContractInfo)
+                        .calculateAvailableAmount(this.height, Nimiq.Policy.coinsToSatoshis(balance));
                     continue;
                 }
 

--- a/src/views/Checkout.vue
+++ b/src/views/Checkout.vue
@@ -129,7 +129,7 @@ export default class Checkout extends Vue {
 
                 if ('type' in accountOrContract && accountOrContract.type === Nimiq.Account.Type.VESTING) {
                     // Calculate available amount for vesting contract
-                    accountOrContract.balance = (accountOrContract as VestingContractInfo)
+                    accountOrContract.balance = accountOrContract
                         .calculateAvailableAmount(this.height, Nimiq.Policy.coinsToSatoshis(balance));
                     continue;
                 }
@@ -170,12 +170,12 @@ export default class Checkout extends Vue {
         let contractInfo: ContractInfo | undefined;
         if (!accountInfo) {
             // Search contracts
-            contractInfo = walletInfo.findContractByAddress(Nimiq.Address.fromUserFriendlyAddress(address));
-            if (contractInfo!.type === Nimiq.Account.Type.HTLC) {
+            contractInfo = walletInfo.findContractByAddress(Nimiq.Address.fromUserFriendlyAddress(address))!;
+            if (contractInfo.type === Nimiq.Account.Type.HTLC) {
                 alert('HTLC contracts are not yet supported for checkout');
                 return;
             }
-            accountInfo = walletInfo.accounts.get((contractInfo as VestingContractInfo).owner.toUserFriendlyAddress());
+            accountInfo = walletInfo.accounts.get(contractInfo.owner.toUserFriendlyAddress());
         }
 
         // FIXME: Currently unused, but should be reactivated

--- a/src/views/CheckoutTransmission.vue
+++ b/src/views/CheckoutTransmission.vue
@@ -2,7 +2,7 @@
     <div class="container pad-bottom">
         <SmallPage>
             <Loader :title="title" :status="status" :state="state" :lightBlue="true"/>
-            <Network :visible="false" ref="network"/>
+            <Network ref="network" :visible="false"/>
         </SmallPage>
     </div>
 </template>

--- a/src/views/ChooseAddress.vue
+++ b/src/views/ChooseAddress.vue
@@ -31,6 +31,8 @@ import staticStore, { Static } from '@/lib/StaticStore';
 import { WalletStore } from '@/lib/WalletStore';
 import { WalletInfo } from '../lib/WalletInfo';
 import { ERROR_CANCELED } from '../lib/Constants';
+import { AccountInfo } from '../lib/AccountInfo';
+import { ContractInfo } from '../lib/ContractInfo';
 
 @Component({components: { AccountSelector, SmallPage }})
 export default class ChooseAddress extends Vue {
@@ -60,10 +62,15 @@ export default class ChooseAddress extends Vue {
             return;
         }
 
-        const accountInfo = walletInfo.accounts.get(address);
+        let accountInfo: AccountInfo | ContractInfo | undefined = walletInfo.accounts.get(address);
         if (!accountInfo) {
-            console.error('Selected address not found:', address);
-            return;
+            // Search contracts
+            accountInfo = walletInfo.findContractByAddress(Nimiq.Address.fromUserFriendlyAddress(address));
+
+            if (!accountInfo) {
+                console.error('Selected address not found:', address);
+                return;
+            }
         }
 
         this.$store.commit('setActiveAccount', {

--- a/src/views/ChooseAddress.vue
+++ b/src/views/ChooseAddress.vue
@@ -62,7 +62,7 @@ export default class ChooseAddress extends Vue {
             return;
         }
 
-        let accountOrContractInfo: AccountInfo | ContractInfo = walletInfo.accounts.get(address) ||
+        const accountOrContractInfo: AccountInfo | ContractInfo = walletInfo.accounts.get(address) ||
             walletInfo.findContractByAddress(Nimiq.Address.fromUserFriendlyAddress(address))!;
 
         this.$store.commit('setActiveAccount', {

--- a/src/views/ChooseAddress.vue
+++ b/src/views/ChooseAddress.vue
@@ -62,25 +62,17 @@ export default class ChooseAddress extends Vue {
             return;
         }
 
-        let accountInfo: AccountInfo | ContractInfo | undefined = walletInfo.accounts.get(address);
-        if (!accountInfo) {
-            // Search contracts
-            accountInfo = walletInfo.findContractByAddress(Nimiq.Address.fromUserFriendlyAddress(address));
-
-            if (!accountInfo) {
-                console.error('Selected address not found:', address);
-                return;
-            }
-        }
+        let accountOrContractInfo: AccountInfo | ContractInfo = walletInfo.accounts.get(address) ||
+            walletInfo.findContractByAddress(Nimiq.Address.fromUserFriendlyAddress(address))!;
 
         this.$store.commit('setActiveAccount', {
             walletId: walletInfo.id,
-            userFriendlyAddress: accountInfo.userFriendlyAddress,
+            userFriendlyAddress: accountOrContractInfo.userFriendlyAddress,
         });
 
         const result: Address = {
-            address: accountInfo.userFriendlyAddress,
-            label: accountInfo.label,
+            address: accountOrContractInfo.userFriendlyAddress,
+            label: accountOrContractInfo.label,
         };
 
         this.$rpc.resolve(result);

--- a/src/views/LoginSuccess.vue
+++ b/src/views/LoginSuccess.vue
@@ -75,10 +75,9 @@ export default class LoginSuccess extends Vue {
             type: this.walletInfos[0].type,
             fileExported: this.walletInfos[0].fileExported,
             wordsExported: this.walletInfos[0].wordsExported,
-            addresses: Array.from(this.walletInfos[0].accounts.values()).map((addressInfo) => ({
-                address: addressInfo.userFriendlyAddress,
-                label: addressInfo.label,
-            })),
+            addresses: Array.from(this.walletInfos[0].accounts.values())
+                .map((addressInfo) => addressInfo.toAddressType()),
+            contracts: this.walletInfos[0].contracts.map((contract) => contract.toContractType()),
         };
 
         this.title = 'Your account is ready.';

--- a/src/views/Rename.vue
+++ b/src/views/Rename.vue
@@ -10,7 +10,7 @@
 
                 <AccountList ref="accountList"
                     :walletId="wallet.id"
-                    :accounts="accounts"
+                    :accounts="accountsAndContractsArray"
                     :editable="true"
                     @account-changed="accountChanged"/>
             </PageBody>
@@ -67,9 +67,12 @@ export default class Rename extends Vue {
     private wallet: WalletInfo | null = null;
     private labelsStored: boolean = false;
 
-    private get accounts() {
+    private get accountsAndContractsArray() {
         if (!this.wallet) return [];
-        return Array.from(this.wallet.accounts.values());
+        return [
+            ...this.wallet.accounts.values(),
+            ...this.wallet.contracts,
+        ];
     }
 
     private get walletIconClass() {
@@ -108,9 +111,19 @@ export default class Rename extends Vue {
 
     private accountChanged(address: string, label: string) {
         const addressInfo = this.wallet!.accounts.get(address);
-        if (!addressInfo) throw new Error('UNEXPECTED: Address that was changed does not exist');
-        addressInfo.label = label;
-        this.wallet!.accounts.set(address, addressInfo);
+        if (addressInfo) {
+            addressInfo.label = label;
+            this.wallet!.accounts.set(address, addressInfo);
+            return;
+        }
+        const contractInfo = this.wallet!.findContractByAddress(Nimiq.Address.fromUserFriendlyAddress(address));
+        if (contractInfo) {
+            contractInfo.label = label;
+            this.wallet!.setContract(contractInfo);
+            return;
+        }
+
+        throw new Error('UNEXPECTED: Address that was changed does not exist');
     }
 
     private onWalletLabelChange(label: string) {
@@ -131,7 +144,7 @@ export default class Rename extends Vue {
             type: this.wallet!.type,
             fileExported: this.wallet!.fileExported,
             wordsExported: this.wallet!.wordsExported,
-            addresses: Array.from(this.accounts.values()).map((addressInfo) => addressInfo.toAddressType()),
+            addresses: Array.from(this.wallet!.accounts.values()).map((addressInfo) => addressInfo.toAddressType()),
             contracts: this.wallet!.contracts.map((contract) => contract.toContractType()),
         };
 

--- a/src/views/Rename.vue
+++ b/src/views/Rename.vue
@@ -131,10 +131,8 @@ export default class Rename extends Vue {
             type: this.wallet!.type,
             fileExported: this.wallet!.fileExported,
             wordsExported: this.wallet!.wordsExported,
-            addresses: Array.from(this.accounts.values()).map((addressInfo) => ({
-                address: addressInfo.userFriendlyAddress,
-                label: addressInfo.label,
-            })),
+            addresses: Array.from(this.accounts.values()).map((addressInfo) => addressInfo.toAddressType()),
+            contracts: this.wallet!.contracts.map((contract) => contract.toContractType()),
         };
 
         this.$rpc.resolve(result);

--- a/src/views/SignTransactionSuccess.vue
+++ b/src/views/SignTransactionSuccess.vue
@@ -7,7 +7,7 @@
                     <h1 class="title nq-h1">Sending your<br>transaction now.</h1>
                 </template>
             </Loader>
-            <Network ref="network"/>
+            <Network ref="network" :visible="false"/>
         </SmallPage>
     </div>
 </template>

--- a/src/views/SignupLedger.vue
+++ b/src/views/SignupLedger.vue
@@ -171,10 +171,9 @@ export default class SignupLedger extends Vue {
                 type: this.walletInfo!.type,
                 fileExported: this.walletInfo!.fileExported,
                 wordsExported: this.walletInfo!.wordsExported,
-                addresses: Array.from(this.walletInfo!.accounts.values()).map((accountInfo) => ({
-                    address: accountInfo.userFriendlyAddress,
-                    label: accountInfo.label,
-                })),
+                addresses: Array.from(this.walletInfo!.accounts.values())
+                    .map((accountInfo) => accountInfo.toAddressType()),
+                contracts: this.walletInfo!.contracts.map((contract) => contract.toContractType()),
             };
             this.$rpc.resolve(result);
         }, Loader.SUCCESS_REDIRECT_DELAY);

--- a/src/views/SignupSuccess.vue
+++ b/src/views/SignupSuccess.vue
@@ -73,6 +73,7 @@ export default class SignupSuccess extends Vue {
                 address: userFriendlyAddress,
                 label: accountInfo.label,
             }],
+            contracts: [], // A newly created account cannot have any contracts
         };
 
         setTimeout(() => this.$rpc.resolve(result), Loader.SUCCESS_REDIRECT_DELAY);

--- a/tests/unit/CookieJar.spec.ts
+++ b/tests/unit/CookieJar.spec.ts
@@ -1,7 +1,6 @@
 import { setup } from './_setup';
 import { WalletType, WalletInfoEntry } from '@/lib/WalletInfo';
 import { AccountInfoEntry } from '@/lib/AccountInfo';
-import { ContractType } from '@/lib/ContractInfo';
 import CookieJar from '@/lib/CookieJar';
 import { Utf8Tools } from '@nimiq/utils';
 

--- a/tests/unit/CookieJar.spec.ts
+++ b/tests/unit/CookieJar.spec.ts
@@ -8,10 +8,13 @@ setup();
 
 const DUMMY_ADDRESS_HR1 = 'NQ86 6D3H 6MVD 2JV4 N77V FNA5 M9BL 2QSP 1P64';
 const DUMMY_ADDRESS_HR2 = 'NQ36 CPYA UTCK VBBG L5GG 8D36 SNHM K8MH DD7X';
+const DUMMY_ADDRESS_HRV = 'NQ76 E5NX K4S8 9RS9 65FC DQ8C H5ML SCYG 81XJ'; // Vesting contract address
 const DUMMY_ADDRESS1: Nimiq.Address = Nimiq.Address.fromUserFriendlyAddress(DUMMY_ADDRESS_HR1);
 const DUMMY_ADDRESS2: Nimiq.Address = Nimiq.Address.fromUserFriendlyAddress(DUMMY_ADDRESS_HR2);
+const DUMMY_ADDRESSV: Nimiq.Address = Nimiq.Address.fromUserFriendlyAddress(DUMMY_ADDRESS_HRV);
 const DUMMY_ADDRESS_S1 = new Uint8Array(DUMMY_ADDRESS1.serialize());
 const DUMMY_ADDRESS_S2 = new Uint8Array(DUMMY_ADDRESS2.serialize());
+const DUMMY_ADDRESS_SV = new Uint8Array(DUMMY_ADDRESSV.serialize());
 const BURN_ADDRESS_HR  = 'NQ07 0000 0000 0000 0000 0000 0000 0000 0000';
 const BURN_ADDRESS  = Nimiq.Address.fromUserFriendlyAddress(BURN_ADDRESS_HR);
 const BURN_ADDRESS_S = new Uint8Array(BURN_ADDRESS.serialize());
@@ -57,7 +60,16 @@ const DUMMY_WALLET_OBJECTS: WalletInfoEntry[] = [
                 },
             ],
         ]),
-        contracts: [], // TODO Add cookie contract encoding
+        contracts: [{
+            type: Nimiq.Account.Type.VESTING,
+            label: 'Vesting Contract',
+            address: DUMMY_ADDRESS_SV,
+            owner: BURN_ADDRESS_S,
+            start: 0,
+            stepAmount: 419229878121,
+            stepBlocks: 2880,
+            totalAmount: 2515379268724,
+        }],
         type: WalletType.LEDGER,
         keyMissing: true,
         fileExported: true,
@@ -122,7 +134,7 @@ const DUMMY_WALLET_OBJECTS: WalletInfoEntry[] = [
                 },
             ],
         ]),
-        contracts: [], // TODO Add cookie contract encoding
+        contracts: [],
         type: WalletType.LEDGER,
         keyMissing: false,
         fileExported: false,
@@ -141,7 +153,16 @@ const DUMMY_WALLET_OBJECTS: WalletInfoEntry[] = [
                 },
             ],
         ]),
-        contracts: [],
+        contracts: [{
+            type: Nimiq.Account.Type.VESTING,
+            label: 'Custom Label',
+            address: DUMMY_ADDRESS_SV,
+            owner: DUMMY_ADDRESS_S2,
+            start: 400000,
+            stepAmount: 419229878121,
+            stepBlocks: 28800,
+            totalAmount: 2515379268724,
+        }],
         type: WalletType.LEGACY,
         keyMissing: false,
         fileExported: true,
@@ -190,7 +211,16 @@ const OUT_DUMMY_WALLET_OBJECTS: WalletInfoEntry[] = [
                 },
             ],
         ]),
-        contracts: [],
+        contracts: [{
+            type: Nimiq.Account.Type.VESTING,
+            label: 'Vesting Contract',
+            address: DUMMY_ADDRESS_SV,
+            owner: BURN_ADDRESS_S,
+            start: 0,
+            stepAmount: 419229878121,
+            stepBlocks: 2880,
+            totalAmount: 2515379268724,
+        }],
         type: WalletType.LEDGER,
         keyMissing: true,
         fileExported: true,
@@ -274,7 +304,16 @@ const OUT_DUMMY_WALLET_OBJECTS: WalletInfoEntry[] = [
                 },
             ],
         ]),
-        contracts: [],
+        contracts: [{
+            type: Nimiq.Account.Type.VESTING,
+            label: 'Custom Label',
+            address: DUMMY_ADDRESS_SV,
+            owner: DUMMY_ADDRESS_S2,
+            start: 400000,
+            stepAmount: 419229878121,
+            stepBlocks: 28800,
+            totalAmount: 2515379268724,
+        }],
         type: WalletType.LEGACY,
         keyMissing: false,
         fileExported: true,
@@ -287,7 +326,7 @@ const BYTES = [
 
     // wallet 1 (BIP39)
     2, // wallet label length (0), wallet type (2)
-    1, // keyMissing = true, fileExported = false, wordsExported = false
+    0b00000001, // Status byte: keyMissing = true, fileExported = false, wordsExported = false, hasContracts = false
     1, 23, // wallet id
     // wallet label (omitted)
     2, // number of accounts
@@ -304,7 +343,7 @@ const BYTES = [
 
     // wallet 2 (LEDGER)
     75, // wallet label length (18), wallet type (3)
-    3, // keyMissing = true, fileExported = true, wordsExported = false
+    0b00001011, // Status byte: keyMissing = true, fileExported = true, wordsExported = false, hasContracts = true
     30, 227, 217, 38, 164, 157, // wallet id
     77, 111, 110, 107, 101, 121, 32, 70, 97, 109, 105, 108, 121, 32, 240, 159, 153, 137, // wallet label
     1, // number of accounts
@@ -314,9 +353,22 @@ const BYTES = [
         68, 97, 110, 105, 101, 108, 39, 115, 32, 76, 101, 100, 103, 101, 114, 32, 226, 157, 164, // account label
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // account address
 
+    // number of contracts
+    1,
+
+        // contract 1
+        1, // contract label length (0), contract type (1)
+        // contract label (omitted)
+        113, 109, 233, 147, 72, 78, 116, 147, 21, 236, 110, 16, 200, 150, 180, 211, 63, 4, 7, 210, // contract address
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // owner address
+        0, 0, 0, 0, // start
+        0, 0, 0, 97, 156, 12, 71, 105, // step amount
+        0, 0, 11, 64, // step blocks
+        0, 0, 2, 73, 168, 73, 172, 116, // total amount
+
     // wallet 3 (LEGACY)
     41, // account label length (10), wallet type (1)
-    5, // keyMissing = true, fileExported = false, wordsExported = true
+    0b00000101, // Status byte: keyMissing = true, fileExported = false, wordsExported = true, hasContracts = false
     1, 5, // wallet id
 
         // account
@@ -325,7 +377,7 @@ const BYTES = [
 
     // wallet 4 (BIP39)
     38, // wallet label length (9), wallet type (2)
-    6, // keyMissing = false, fileExported = true, wordsExported = true
+    0b00000110, // Status byte: keyMissing = false, fileExported = true, wordsExported = true, hasContracts = false
     1, 7, // wallet id
     77, 97, 105, 110, 32, 240, 159, 153, 137, // wallet label
     2, // number of accounts
@@ -342,7 +394,7 @@ const BYTES = [
 
     // wallet 5 (LEDGER)
     3, // wallet label length (0), wallet type (3)
-    0, // keyMissing = false, fileExported = false, wordsExported = false
+    0b00000000, // Status byte: keyMissing = false, fileExported = false, wordsExported = false, hasContracts = false
     30, 227, 217, 38, 164, 160, // wallet id
     // wallet label (omitted)
     1, // number of accounts
@@ -354,12 +406,25 @@ const BYTES = [
 
     // wallet 6 (LEGACY)
     41, // account label length (10), wallet type (1)
-    2, // keyMissing = false, fileExported = true, wordsExported = false
+    0b00001010, // Status byte: keyMissing = false, fileExported = true, wordsExported = false, hasContracts = true
     3, 137, 84, 64, // wallet id
 
         // account
         79, 108, 100, 65, 100, 100, 114, 101, 115, 115, // account label
         101, 254, 174, 109, 147, 234, 215, 10, 22, 16, 67, 70, 109, 90, 53, 154, 43, 22, 180, 254, // account address
+
+    // number of contracts
+    1,
+
+        // contract 1
+        49, // contract label length (12), contract type (1)
+        67, 117, 115, 116, 111, 109, 32, 76, 97, 98, 101, 108, // contract label
+        113, 109, 233, 147, 72, 78, 116, 147, 21, 236, 110, 16, 200, 150, 180, 211, 63, 4, 7, 210, // contract address
+        101, 254, 174, 109, 147, 234, 215, 10, 22, 16, 67, 70, 109, 90, 53, 154, 43, 22, 180, 254, // owner address
+        0, 6, 26, 128, // start
+        0, 0, 0, 97, 156, 12, 71, 105, // step amount
+        0, 0, 112, 128, // step blocks
+        0, 0, 2, 73, 168, 73, 172, 116, // total amount
 ];
 
 const BASE64 = Nimiq.BufferUtils.toBase64(new Uint8Array(BYTES));

--- a/tests/unit/CookieJar.spec.ts
+++ b/tests/unit/CookieJar.spec.ts
@@ -58,12 +58,7 @@ const DUMMY_WALLET_OBJECTS: WalletInfoEntry[] = [
                 },
             ],
         ]),
-        contracts: [{
-            address: DUMMY_ADDRESS1,
-            label: 'Savings',
-            ownerPath: 'm/44\'/242\'/0\'/0\'',
-            type: ContractType.VESTING,
-        }],
+        contracts: [], // TODO Add cookie contract encoding
         type: WalletType.LEDGER,
         keyMissing: true,
         fileExported: true,
@@ -128,12 +123,7 @@ const DUMMY_WALLET_OBJECTS: WalletInfoEntry[] = [
                 },
             ],
         ]),
-        contracts: [{
-            address: DUMMY_ADDRESS1,
-            label: 'Vesting Contract',
-            ownerPath: 'm/44\'/242\'/0\'/0\'',
-            type: ContractType.VESTING,
-        }],
+        contracts: [], // TODO Add cookie contract encoding
         type: WalletType.LEDGER,
         keyMissing: false,
         fileExported: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -772,9 +772,9 @@
   resolved "https://registry.yarnpkg.com/@nimiq/utils/-/utils-0.3.0.tgz#9e2e75c3072f6e276a41c9ddd4f0a7df010bff83"
   integrity sha512-00aTQPtKpXIUz3ZJVrhWIjMPXvSvaY5SygDJwGIPDcP/KYii8FvqWqaYUoKfLe5dRwLxY4kM/Qdw6hWkLdWOBg==
 
-"@nimiq/vue-components@https://github.com/nimiq/vue-components.git#build/accounts-soeren-contracts":
+"@nimiq/vue-components@https://github.com/nimiq/vue-components.git#build/accounts":
   version "0.1.0"
-  resolved "https://github.com/nimiq/vue-components.git#e5f4371236a67517a24b84c72942627adfc2f8d4"
+  resolved "https://github.com/nimiq/vue-components.git#c1fc9ee6a1d0065d1790c1d5de5746b93849dc38"
   dependencies:
     vue "^2.5.17"
     vue-property-decorator "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -772,9 +772,9 @@
   resolved "https://registry.yarnpkg.com/@nimiq/utils/-/utils-0.3.0.tgz#9e2e75c3072f6e276a41c9ddd4f0a7df010bff83"
   integrity sha512-00aTQPtKpXIUz3ZJVrhWIjMPXvSvaY5SygDJwGIPDcP/KYii8FvqWqaYUoKfLe5dRwLxY4kM/Qdw6hWkLdWOBg==
 
-"@nimiq/vue-components@https://github.com/nimiq/vue-components.git#build/accounts":
+"@nimiq/vue-components@https://github.com/nimiq/vue-components.git#build/accounts-soeren-contracts":
   version "0.1.0"
-  resolved "https://github.com/nimiq/vue-components.git#2b27d3a9557b7b8643a08699866d77a4ca080f1a"
+  resolved "https://github.com/nimiq/vue-components.git#e5f4371236a67517a24b84c72942627adfc2f8d4"
   dependencies:
     vue "^2.5.17"
     vue-property-decorator "^7.0.0"


### PR DESCRIPTION
Resolves #124.

For testing, you can import this legacy account that owns a genesis vesting contract in the testnet:
```
[
    "engine",  "curtain",  "fringe",
    "bean",    "hole",     "foot", 
    "garage",  "bean",     "find",
    "suit",    "ozone",    "kitchen",
    "country", "stool",    "talent", 
    "smoke",   "double",   "similar", 
    "hazard",  "discover", "gauge", 
    "gasp",    "settle",   "fabric"
]
```

or use latest Keyguard `master` branch and use the _Setup Legacy Accounts_ and _Migrate Legacy Accounts_ options in the Accounts Demos to import this account through migration.