### PR TITLE
Small window reload fixes

### DIFF
--- a/src/components/Network.vue
+++ b/src/components/Network.vue
@@ -36,9 +36,6 @@ class Network extends Vue {
         return client.connectPico(addresses);
     }
 
-    // Uint8Arrays cannot be stored in SessionStorage, thus the stored request has arrays instead and is
-    // thus not exactly the type KSignTransactionRequest. Thus all potential Uint8Arrays are converted
-    // into Nimiq.SerialBuffers (sender, recipient, data).
     public async prepareTx(
         keyguardRequest: KeyguardClient.SignTransactionRequest,
         keyguardResult: KeyguardClient.SignTransactionResult,
@@ -53,15 +50,15 @@ class Network extends Vue {
             || keyguardRequest.recipientType !== Nimiq.Account.Type.BASIC
         ) {
             tx = new Nimiq.ExtendedTransaction(
-                new Nimiq.Address(new Nimiq.SerialBuffer(keyguardRequest.sender)),
+                new Nimiq.Address(keyguardRequest.sender),
                 keyguardRequest.senderType || Nimiq.Account.Type.BASIC,
-                new Nimiq.Address(new Nimiq.SerialBuffer(keyguardRequest.recipient)),
+                new Nimiq.Address(keyguardRequest.recipient),
                 keyguardRequest.recipientType || Nimiq.Account.Type.BASIC,
                 keyguardRequest.value,
                 keyguardRequest.fee,
                 keyguardRequest.validityStartHeight,
                 keyguardRequest.flags || 0,
-                new Nimiq.SerialBuffer(keyguardRequest.data || 0),
+                keyguardRequest.data || new Uint8Array(0),
                 Nimiq.SignatureProof.singleSig(
                     new Nimiq.PublicKey(keyguardResult.publicKey),
                     new Nimiq.Signature(keyguardResult.signature),
@@ -70,7 +67,7 @@ class Network extends Vue {
         } else {
             tx = new Nimiq.BasicTransaction(
                 new Nimiq.PublicKey(keyguardResult.publicKey),
-                new Nimiq.Address(new Nimiq.SerialBuffer(keyguardRequest.recipient)),
+                new Nimiq.Address(keyguardRequest.recipient),
                 keyguardRequest.value,
                 keyguardRequest.fee,
                 keyguardRequest.validityStartHeight,

--- a/src/lib/LedgerApi.ts
+++ b/src/lib/LedgerApi.ts
@@ -327,7 +327,7 @@ class LedgerApi {
 
         // prepare tx outside of request to avoid that an error would result in an endless loop in _callLedger
         const senderPubKeyBytes = await LedgerApi.getPublicKey(keyPath);
-        const senderPubKey = Nimiq.PublicKey.unserialize(new Nimiq.SerialBuffer(senderPubKeyBytes));
+        const senderPubKey = new Nimiq.PublicKey(senderPubKeyBytes);
         const senderAddress = senderPubKey.toAddress().toUserFriendlyAddress();
         if (transaction.sender.replace(/ /g, '')
             !== senderAddress.replace(/ /g, '')) {
@@ -350,7 +350,7 @@ class LedgerApi {
         requestParams.transactionToSign = nimiqTx;
 
         const signatureBytes = await LedgerApi._callLedger(request);
-        const signature = Nimiq.Signature.unserialize(new Nimiq.SerialBuffer(signatureBytes));
+        const signature = new Nimiq.Signature(signatureBytes);
         const proof = Nimiq.SignatureProof.singleSig(senderPubKey, signature);
         return {
             ...transaction,

--- a/src/lib/RpcApi.ts
+++ b/src/lib/RpcApi.ts
@@ -147,6 +147,12 @@ export default class RpcApi {
                     hasRequest: !!this._staticStore.request,
                 });
 
+                if (location.pathname !== '/') {
+                    // Don't jump back to request's initial view on reload when navigated to a subsequent view.
+                    // E.g. if the user switches from Checkout to Import, don't jump back to Checkout on reload.
+                    return;
+                }
+
                 let account;
                 if (request && 'walletId' in request) {
                     account = await WalletStore.Instance.get((request as ParsedSimpleRequest).walletId);

--- a/src/lib/StaticStore.ts
+++ b/src/lib/StaticStore.ts
@@ -3,6 +3,7 @@ import { createDecorator } from 'vue-class-component';
 import { ParsedRpcRequest, RequestType } from './RequestTypes';
 import { RpcResult } from './PublicRequestTypes';
 import { State as RpcState } from '@nimiq/rpc';
+import { Request as KeyguardRequest } from '@nimiq/keyguard-client';
 
 export class StaticStore {
     private static instance: StaticStore;
@@ -16,7 +17,7 @@ export class StaticStore {
     public request?: ParsedRpcRequest;
     public kind?: RequestType;
     public rpcState?: RpcState;
-    public keyguardRequest?: any;
+    public keyguardRequest?: KeyguardRequest;
     public originalRouteName?: string;
     public sideResult?: RpcResult | Error;
 }

--- a/src/views/Checkout.vue
+++ b/src/views/Checkout.vue
@@ -195,6 +195,7 @@ export default class Checkout extends Vue {
             data: this.request.data,
             flags: this.request.flags,
         };
+
         staticStore.keyguardRequest = request;
 
         const client = this.$rpc.createKeyguardClient();

--- a/src/views/Checkout.vue
+++ b/src/views/Checkout.vue
@@ -195,13 +195,7 @@ export default class Checkout extends Vue {
             data: this.request.data,
             flags: this.request.flags,
         };
-
-        const storedRequest = Object.assign({}, request, {
-            sender: Array.from(request.sender),
-            recipient: Array.from(request.recipient),
-            data: Array.from(request.data!),
-        });
-        staticStore.keyguardRequest = storedRequest;
+        staticStore.keyguardRequest = request;
 
         const client = this.$rpc.createKeyguardClient();
         client.signTransaction(request);

--- a/src/views/CheckoutTransmission.vue
+++ b/src/views/CheckoutTransmission.vue
@@ -18,7 +18,6 @@ import KeyguardClient from '@nimiq/keyguard-client';
 
 @Component({components: {Loader, Network, SmallPage}})
 export default class CheckoutTransmission extends Vue {
-    // The stored keyguardRequest does not have Uint8Arrays, only regular arrays
     @Static private keyguardRequest!: KeyguardClient.SignTransactionRequest;
     @State private keyguardResult!: KeyguardClient.SignTransactionResult;
 

--- a/src/views/SignMessage.vue
+++ b/src/views/SignMessage.vue
@@ -98,11 +98,7 @@ export default class SignMessage extends Vue {
             signerLabel: accountInfo.label,
         };
 
-        const storedRequest = Object.assign({}, request, {
-            signer: Array.from(request.signer),
-            message: Array.from(request.message as Uint8Array),
-        });
-        staticStore.keyguardRequest = storedRequest;
+        staticStore.keyguardRequest = request;
 
         const client = this.$rpc.createKeyguardClient();
         client.signMessage(request);

--- a/src/views/SignMessageSuccess.vue
+++ b/src/views/SignMessageSuccess.vue
@@ -25,13 +25,12 @@ import { Utf8Tools } from '@nimiq/utils';
 @Component({components: {Loader, SmallPage}})
 export default class SignMessageSuccess extends Vue {
     @Static private request!: ParsedSignMessageRequest;
-    // The stored keyguardRequest does not have Uint8Array, only regular arrays
     @Static private keyguardRequest!: KeyguardClient.SignMessageRequest;
     @State private keyguardResult!: KeyguardClient.SignMessageResult;
 
     private mounted() {
         const result: SignedMessage = {
-            signer: new Nimiq.Address(new Uint8Array(this.keyguardRequest.signer)).toUserFriendlyAddress(),
+            signer: new Nimiq.Address(this.keyguardRequest.signer).toUserFriendlyAddress(),
             signerPublicKey: this.keyguardResult.publicKey,
             signature: this.keyguardResult.signature,
             message: typeof this.request.message === 'string'

--- a/src/views/SignTransaction.vue
+++ b/src/views/SignTransaction.vue
@@ -46,12 +46,7 @@ export default class SignTransaction extends Vue {
             flags: this.request.flags,
         };
 
-        const storedRequest = Object.assign({}, request, {
-            sender: Array.from(request.sender),
-            recipient: Array.from(request.recipient),
-            data: Array.from(request.data || []),
-        });
-        staticStore.keyguardRequest = storedRequest;
+        staticStore.keyguardRequest = request;
 
         const client = this.$rpc.createKeyguardClient();
         client.signTransaction(request);

--- a/src/views/SignTransactionSuccess.vue
+++ b/src/views/SignTransactionSuccess.vue
@@ -24,7 +24,6 @@ import KeyguardClient from '@nimiq/keyguard-client';
 
 @Component({components: {Network, SmallPage, Loader}})
 export default class SignTransactionSuccess extends Vue {
-    // The stored keyguardRequest does not have Uint8Array, only regular arrays
     @Static private keyguardRequest!: KeyguardClient.SignTransactionRequest;
     @State private keyguardResult!: KeyguardClient.SignTransactionResult;
 


### PR DESCRIPTION
Small cleanup and fix for reload behavior:
- Don't transform `Uint8Array`s in stored `staticStore.keyguardRequest` as the `RpcApi` is able to handle them directly.
- Don't jump back to request's initial view on reload when navigated to a subsequent view. Relevant when user navigates from checkout to onboarding and reloads, from checkout to SignTransactionLedger and reloads or from onboarding to SignupLedger and reloads.