### PR TITLE
KEY_NOT_FOUND error page and hiding keyMissing accounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     },
     "dependencies": {
         "@nimiq/iqons": "^1.4.2",
-        "@nimiq/keyguard-client": "^0.4.0",
+        "@nimiq/keyguard-client": "^0.4.2",
         "@nimiq/ledgerjs": "https://github.com/nimiq/ledger-api.git",
         "@nimiq/network-client": "^0.2.0",
         "@nimiq/rpc": "^0.1.4",

--- a/src/components/Loader.vue
+++ b/src/components/Loader.vue
@@ -327,6 +327,11 @@ export default Loader;
         padding-bottom: 2rem;
     }
 
+    .action-row .nq-link {
+        color: white;
+        font-size: 2rem;
+    }
+
     /* FADE transitions */
 
     .fade-loading-leave-active,

--- a/src/iframe.ts
+++ b/src/iframe.ts
@@ -24,7 +24,9 @@ class IFrameApi {
             wallets = await WalletStore.Instance.list();
         }
         if (wallets.length > 0) {
-            return wallets.map((wallet) => WalletInfo.objectToAccountType(wallet));
+            return wallets
+                .filter((wallet) => !wallet.keyMissing)
+                .map((wallet) => WalletInfo.objectToAccountType(wallet));
         }
 
         // If no wallets exist, see if the Keyguard has keys

--- a/src/lib/WalletInfoCollector.ts
+++ b/src/lib/WalletInfoCollector.ts
@@ -201,7 +201,10 @@ export default class WalletInfoCollector {
         }
 
         const existingWalletInfo = await WalletStore.Instance.get(walletId);
-        if (existingWalletInfo) return existingWalletInfo;
+        if (existingWalletInfo) {
+            existingWalletInfo.keyMissing = false;
+            return existingWalletInfo;
+        }
 
         const label = walletType === WalletType.LEGACY
             ? ACCOUNT_DEFAULT_LABEL_LEGACY

--- a/src/store.ts
+++ b/src/store.ts
@@ -135,6 +135,7 @@ const store: StoreOptions<RootState> = {
             const singleContracts: ContractInfo[] = [];
 
             const processedWallets = state.wallets.filter((wallet) => {
+                if (wallet.keyMissing) return false;
                 if (wallet.type !== WalletType.LEGACY) return true;
 
                 const [singleAccountAddress, singleAccountInfo] = Array.from(wallet.accounts.entries())[0];

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -14,7 +14,6 @@ export default class Login extends Vue {
     public created() {
         const request: KeyguardClient.ImportRequest = {
             appName: this.request.appName,
-            defaultKeyPath: DEFAULT_KEY_PATH,
             requestedKeyPaths: [DEFAULT_KEY_PATH],
         };
 

--- a/src/views/OnboardingSelector.vue
+++ b/src/views/OnboardingSelector.vue
@@ -33,7 +33,6 @@ export default class OnboardingSelector extends Vue {
     private login() {
         const request: KeyguardClient.ImportRequest = {
             appName: this.request.appName,
-            defaultKeyPath: DEFAULT_KEY_PATH,
             requestedKeyPaths: [DEFAULT_KEY_PATH],
         };
         const client = this.$rpc.createKeyguardClient();

--- a/yarn.lock
+++ b/yarn.lock
@@ -727,10 +727,10 @@
     levelup "^2.0.2"
     node-lmdb "0.6.0"
 
-"@nimiq/keyguard-client@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@nimiq/keyguard-client/-/keyguard-client-0.4.0.tgz#7400540fc743aed275aa9d9aae7fba261705c5e4"
-  integrity sha512-y9aTl/fjsIhXvn95Oq7n7T/aK6YvzkEi6zzoWX0BeZHChl5oK3ymY2Vk1pKDhWBMb0fQlr5rD0SMoGNjgoPSbg==
+"@nimiq/keyguard-client@^0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@nimiq/keyguard-client/-/keyguard-client-0.4.2.tgz#a91b13420c8e72fceed365ac39bc114125374ae0"
+  integrity sha512-CLbJaCo1nNDUTFG6nx25sQm8GC0a+PDHlBw/1N3fINOml2mh/BLHAplUEqi9YXOnuMiKIRpewpHFSgh/tDbWyA==
   dependencies:
     "@nimiq/core-web" "1.4.3"
     "@nimiq/rpc" "^0.1.4"


### PR DESCRIPTION
Accounts marked with `keyMissing = true` will be able to be also managed in the revamped management screen (#170). Until then, they will simply be hidden from apps.

Resolves #121.