### PR TITLE
Generate proper sourcemaps for .ts files

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -21,6 +21,18 @@ const configureWebpack = {
             config: path.join(__dirname, `config.${buildName}.ts`)
         }
     },
+    // Fix sourcemaps (https://www.mistergoodcat.com/post/the-joy-that-is-source-maps-with-vuejs-and-typescript)
+    devtool: 'eval-source-map',
+    output: {
+        devtoolModuleFilenameTemplate: info => {
+            var $filename = 'sources://' + info.resourcePath;
+            if (info.resourcePath.match(/\.vue$/) && !info.query.match(/type=script/)) {
+                $filename = 'webpack-generated:///' + info.resourcePath + '?' + info.hash;
+            }
+            return $filename;
+        },
+        devtoolFallbackModuleFilenameTemplate: 'webpack:///[resource-path]?[hash]',
+    },
 };
 
 module.exports = {


### PR DESCRIPTION
Following the instructions from https://www.mistergoodcat.com/post/the-joy-that-is-source-maps-with-vuejs-and-typescript.

The breakpoint-able `.ts` and `.vue` files are now available in the devtools' sources under the `.` folder.

Resolves #127.