### PR TITLE
Request parsing: required and default properties, extraData as string

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,9 +192,9 @@ const requestOptions = {
     //fee: 138,
 
     // [optional] Extra data that should be sent with the transaction.
-    // Type: Uint8Array | Nimiq.SerialBuffer
+    // Type: string | Uint8Array | Nimiq.SerialBuffer
     // Default: new Uint8Array(0)
-    //extraData: Nimiq.BufferUtils.fromAscii('Hello Nimiq!'),
+    //extraData: 'Hello Nimiq!',
 
     // [optional] Nimiq.Transaction.Flag, only required if the transaction
     // creates a contract.

--- a/src/lib/PublicRequestTypes.ts
+++ b/src/lib/PublicRequestTypes.ts
@@ -20,7 +20,7 @@ export interface SignTransactionRequest extends SimpleRequest {
     recipientType?: Nimiq.Account.Type;
     value: number;
     fee?: number;
-    extraData?: Uint8Array;
+    extraData?: Uint8Array | string;
     flags?: number;
     validityStartHeight: number; // FIXME To be made optional when accounts manager has its own network
 }
@@ -31,7 +31,7 @@ export interface CheckoutRequest extends BasicRequest {
     recipientType?: Nimiq.Account.Type;
     value: number;
     fee?: number;
-    extraData?: Uint8Array;
+    extraData?: Uint8Array | string;
     flags?: number;
     validityDuration?: number;
 }

--- a/src/lib/RequestParser.ts
+++ b/src/lib/RequestParser.ts
@@ -25,6 +25,10 @@ export class RequestParser {
         switch (requestType) {
             case RequestType.SIGN_TRANSACTION:
                 const signTransactionRequest = request as SignTransactionRequest;
+
+                if (!signTransactionRequest.value) throw new Error ('value is required');
+                if (!signTransactionRequest.validityStartHeight) throw new Error('validityStartHeight is required');
+
                 return {
                     kind: RequestType.SIGN_TRANSACTION,
                     appName: signTransactionRequest.appName,
@@ -40,6 +44,8 @@ export class RequestParser {
                 } as ParsedSignTransactionRequest;
             case RequestType.CHECKOUT:
                 const checkoutRequest = request as CheckoutRequest;
+
+                if (!checkoutRequest.value) throw new Error ('value is required');
                 if (checkoutRequest.shopLogoUrl && new URL(checkoutRequest.shopLogoUrl).origin !== state.origin) {
                     throw new Error(
                         'shopLogoUrl must have same origin as caller website. Image at ' +
@@ -79,6 +85,9 @@ export class RequestParser {
             case RequestType.LOGOUT:
             case RequestType.ADD_ADDRESS:
                 const simpleRequest = request as SimpleRequest;
+
+                if (!simpleRequest.accountId) throw new Error('accountId is required');
+
                 return {
                     kind: requestType,
                     appName: simpleRequest.appName,
@@ -86,6 +95,9 @@ export class RequestParser {
                 } as ParsedSimpleRequest;
             case RequestType.RENAME:
                 const renameRequest = request as RenameRequest;
+
+                if (!renameRequest.accountId) throw new Error('accountId is required');
+
                 return {
                     kind: RequestType.RENAME,
                     appName: renameRequest.appName,

--- a/src/lib/RequestParser.ts
+++ b/src/lib/RequestParser.ts
@@ -19,6 +19,7 @@ import {
     ParsedRenameRequest,
     ParsedRpcRequest,
 } from './RequestTypes';
+import { Utf8Tools } from '@nimiq/utils';
 
 export class RequestParser {
     public static parse(request: RpcRequest, state: State, requestType: RequestType): ParsedRpcRequest | null {
@@ -38,7 +39,9 @@ export class RequestParser {
                     recipientType: signTransactionRequest.recipientType || Nimiq.Account.Type.BASIC,
                     value: signTransactionRequest.value,
                     fee: signTransactionRequest.fee || 0,
-                    data: signTransactionRequest.extraData || new Uint8Array(0),
+                    data: typeof signTransactionRequest.extraData === 'string'
+                        ? Utf8Tools.stringToUtf8ByteArray(signTransactionRequest.extraData)
+                        : signTransactionRequest.extraData || new Uint8Array(0),
                     flags: signTransactionRequest.flags || Nimiq.Transaction.Flag.NONE,
                     validityStartHeight: signTransactionRequest.validityStartHeight,
                 } as ParsedSignTransactionRequest;
@@ -61,7 +64,9 @@ export class RequestParser {
                     recipientType: checkoutRequest.recipientType || Nimiq.Account.Type.BASIC,
                     value: checkoutRequest.value,
                     fee: checkoutRequest.fee || 0,
-                    data: checkoutRequest.extraData || new Uint8Array(0),
+                    data: typeof checkoutRequest.extraData === 'string'
+                        ? Utf8Tools.stringToUtf8ByteArray(checkoutRequest.extraData)
+                        : checkoutRequest.extraData || new Uint8Array(0),
                     flags: checkoutRequest.flags || Nimiq.Transaction.Flag.NONE,
                     validityDuration: !checkoutRequest.validityDuration ? TX_VALIDITY_WINDOW : Math.min(
                         TX_VALIDITY_WINDOW,

--- a/src/lib/RequestParser.ts
+++ b/src/lib/RequestParser.ts
@@ -23,6 +23,8 @@ import { Utf8Tools } from '@nimiq/utils';
 
 export class RequestParser {
     public static parse(request: RpcRequest, state: State, requestType: RequestType): ParsedRpcRequest | null {
+        if (!request.appName) throw new Error('appName is required');
+
         switch (requestType) {
             case RequestType.SIGN_TRANSACTION:
                 const signTransactionRequest = request as SignTransactionRequest;

--- a/src/lib/RequestParser.ts
+++ b/src/lib/RequestParser.ts
@@ -31,11 +31,11 @@ export class RequestParser {
                     walletId: signTransactionRequest.accountId,
                     sender: Nimiq.Address.fromUserFriendlyAddress(signTransactionRequest.sender),
                     recipient: Nimiq.Address.fromUserFriendlyAddress(signTransactionRequest.recipient),
-                    recipientType: signTransactionRequest.recipientType,
+                    recipientType: signTransactionRequest.recipientType || Nimiq.Account.Type.BASIC,
                     value: signTransactionRequest.value,
-                    fee: signTransactionRequest.fee,
-                    data: signTransactionRequest.extraData,
-                    flags: signTransactionRequest.flags,
+                    fee: signTransactionRequest.fee || 0,
+                    data: signTransactionRequest.extraData || new Uint8Array(0),
+                    flags: signTransactionRequest.flags || Nimiq.Transaction.Flag.NONE,
                     validityStartHeight: signTransactionRequest.validityStartHeight,
                 } as ParsedSignTransactionRequest;
             case RequestType.CHECKOUT:
@@ -52,11 +52,11 @@ export class RequestParser {
                     appName: checkoutRequest.appName,
                     shopLogoUrl: checkoutRequest.shopLogoUrl,
                     recipient: Nimiq.Address.fromUserFriendlyAddress(checkoutRequest.recipient),
-                    recipientType: checkoutRequest.recipientType,
+                    recipientType: checkoutRequest.recipientType || Nimiq.Account.Type.BASIC,
                     value: checkoutRequest.value,
-                    fee: checkoutRequest.fee,
-                    data: checkoutRequest.extraData,
-                    flags: checkoutRequest.flags,
+                    fee: checkoutRequest.fee || 0,
+                    data: checkoutRequest.extraData || new Uint8Array(0),
+                    flags: checkoutRequest.flags || Nimiq.Transaction.Flag.NONE,
                     validityDuration: !checkoutRequest.validityDuration ? TX_VALIDITY_WINDOW : Math.min(
                         TX_VALIDITY_WINDOW,
                         Math.max(

--- a/src/lib/RequestParser.ts
+++ b/src/lib/RequestParser.ts
@@ -27,7 +27,7 @@ export class RequestParser {
             case RequestType.SIGN_TRANSACTION:
                 const signTransactionRequest = request as SignTransactionRequest;
 
-                if (!signTransactionRequest.value) throw new Error ('value is required');
+                if (!signTransactionRequest.value) throw new Error('value is required');
                 if (!signTransactionRequest.validityStartHeight) throw new Error('validityStartHeight is required');
 
                 return {
@@ -48,7 +48,7 @@ export class RequestParser {
             case RequestType.CHECKOUT:
                 const checkoutRequest = request as CheckoutRequest;
 
-                if (!checkoutRequest.value) throw new Error ('value is required');
+                if (!checkoutRequest.value) throw new Error('value is required');
                 if (checkoutRequest.shopLogoUrl && new URL(checkoutRequest.shopLogoUrl).origin !== state.origin) {
                     throw new Error(
                         'shopLogoUrl must have same origin as caller website. Image at ' +

--- a/src/lib/RequestTypes.ts
+++ b/src/lib/RequestTypes.ts
@@ -28,22 +28,22 @@ export interface ParsedSignTransactionRequest extends ParsedSimpleRequest {
     walletId: string;
     sender: Nimiq.Address;
     recipient: Nimiq.Address;
-    recipientType?: Nimiq.Account.Type;
+    recipientType: Nimiq.Account.Type;
     value: number;
-    fee?: number;
-    data?: Uint8Array;
-    flags?: number;
+    fee: number;
+    data: Uint8Array;
+    flags: number;
     validityStartHeight: number; // FIXME To be made optional when accounts manager has its own network
 }
 
 export interface ParsedCheckoutRequest extends ParsedBasicRequest {
     shopLogoUrl?: string;
     recipient: Nimiq.Address;
-    recipientType?: Nimiq.Account.Type;
+    recipientType: Nimiq.Account.Type;
     value: number;
-    fee?: number;
-    data?: Uint8Array;
-    flags?: number;
+    fee: number;
+    data: Uint8Array;
+    flags: number;
     validityDuration: number;
 }
 

--- a/src/views/Checkout.vue
+++ b/src/views/Checkout.vue
@@ -190,7 +190,7 @@ export default class Checkout extends Vue {
             recipientType: this.request.recipientType,
             // recipientLabel: '', // Checkout is using the shopOrigin instead
             value: this.request.value,
-            fee: this.request.fee || 0,
+            fee: this.request.fee,
             validityStartHeight,
             data: this.request.data,
             flags: this.request.flags,
@@ -217,7 +217,7 @@ export default class Checkout extends Vue {
     }
 
     private get hasSufficientBalanceAccount(): boolean {
-        const minBalance = this.request.value + (this.request.fee || 0);
+        const minBalance = this.request.value + this.request.fee;
         return this.wallets.some((wallet: WalletInfo) => {
             return Array.from(wallet.accounts.values()).some((account: AccountInfo) => {
                 return !!account.balance && account.balance >= minBalance;

--- a/src/views/SignTransaction.vue
+++ b/src/views/SignTransaction.vue
@@ -40,7 +40,7 @@ export default class SignTransaction extends Vue {
             recipientType: this.request.recipientType,
             recipientLabel: undefined, // XXX Should we accept a recipient label from outside?
             value: this.request.value,
-            fee: this.request.fee || 0,
+            fee: this.request.fee,
             validityStartHeight: this.request.validityStartHeight,
             data: this.request.data,
             flags: this.request.flags,


### PR DESCRIPTION
Resolves #190.

- Enforce minimum set of required request properties
- Set defaults for optional properties to clean up setting fallbacks throughout the code
- Allow `extraData` for checkout and signTransaction to be a string

This actually fixes a bug in vue-components/PaymentInfoLine, where it displayed 'NaN NIM' when `fee` was omitted in the checkout request.