### PR TITLE
Use Account[] for list and migration results

### DIFF
--- a/demos/Demo.ts
+++ b/demos/Demo.ts
@@ -12,10 +12,8 @@ import {
     RenameRequest,
     SignMessageRequest,
 } from '../src/lib/PublicRequestTypes';
-import { WalletInfoEntry } from '../src/lib/WalletInfo';
 import { RedirectRequestBehavior } from '../client/RequestBehavior';
 import { Utf8Tools } from '@nimiq/utils';
-import AddressUtils from '../src/lib/AddressUtils';
 
 class Demo {
     public static run() {
@@ -297,7 +295,7 @@ class Demo {
         document.querySelector('#result').textContent = 'Legacy Account stored';
     }
 
-    public async list(): Promise<WalletInfoEntry[]> {
+    public async list(): Promise<Account[]> {
         return await this._accountsClient.list();
     }
 
@@ -401,32 +399,31 @@ class Demo {
         let html = '';
 
         wallets.forEach(wallet => {
-            html += `<li${wallet.keyMissing ? ' style="color:red;"' : ''}>${wallet.label}<br>
-                        <button class="export" data-wallet-id="${wallet.id}">Export</button>
-                        <button class="change-password" data-wallet-id="${wallet.id}">Ch. Pass.</button>
-                        ${wallet.type !== 0 ? `<button class="add-account" data-wallet-id="${wallet.id}">+ Acc</button>` : ''}
-                        <button class="rename" data-wallet-id="${wallet.id}">Rename</button>
-                        <button class="logout" data-wallet-id="${wallet.id}">Logout</button>
+            html += `<li>${wallet.label}<br>
+                        <button class="export" data-wallet-id="${wallet.accountId}">Export</button>
+                        <button class="change-password" data-wallet-id="${wallet.accountId}">Ch. Pass.</button>
+                        ${wallet.type !== 0 ? `<button class="add-account" data-wallet-id="${wallet.accountId}">+ Acc</button>` : ''}
+                        <button class="rename" data-wallet-id="${wallet.accountId}">Rename</button>
+                        <button class="logout" data-wallet-id="${wallet.accountId}">Logout</button>
                         <ul>`;
-            wallet.accounts.forEach((acc, addr) => {
+            wallet.addresses.forEach((acc) => {
                 html += `
                             <li>
                                 <label>
-                                    <input type="radio" name="sign-tx-address" data-address="${addr}" data-wallet-id="${wallet.id}">
+                                    <input type="radio" name="sign-tx-address" data-address="${acc.address}" data-wallet-id="${wallet.accountId}">
                                     ${acc.label}
-                                    <button class="rename" data-wallet-id="${wallet.id}" data-address="${addr}">Rename</button>
+                                    <button class="rename" data-wallet-id="${wallet.accountId}" data-address="${acc.address}">Rename</button>
                                 </label>
                             </li>
                 `;
             });
             wallet.contracts.forEach((con) => {
-                const addr = AddressUtils.toUserFriendlyAddress(con.address);
                 html += `
                             <li>
                                 <label>
-                                    <input type="radio" name="sign-tx-address" data-address="${addr}" data-wallet-id="${wallet.id}">
+                                    <input type="radio" name="sign-tx-address" data-address="${con.address}" data-wallet-id="${wallet.accountId}">
                                     <strong>Contract</strong> ${con.label}
-                                    <button class="rename" data-wallet-id="${wallet.id}" data-address="${addr}">Rename</button>
+                                    <button class="rename" data-wallet-id="${wallet.accountId}" data-address="${con.address}">Rename</button>
                                 </label>
                             </li>
                 `;

--- a/public/iframe.html
+++ b/public/iframe.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <script src="https://cdn.nimiq-testnet.com/web-offline.js"></script>
     <title>Nimiq Accounts Manager IFrame</title>
   </head>
   <body>

--- a/public/iframe.html
+++ b/public/iframe.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <script src="https://cdn.nimiq-testnet.com/web-offline.js"></script>
     <title>Nimiq Accounts Manager IFrame</title>
   </head>
   <body>

--- a/src/iframe.ts
+++ b/src/iframe.ts
@@ -1,9 +1,10 @@
 import { RpcServer } from '@nimiq/rpc';
 import { BrowserDetection } from '@nimiq/utils';
 import { WalletStore } from '@/lib/WalletStore';
-import { WalletInfoEntry } from '@/lib/WalletInfo';
+import { WalletInfoEntry, WalletInfo } from '@/lib/WalletInfo';
 import CookieJar from '@/lib/CookieJar';
 import Config from 'config';
+import { ListResult } from './lib/PublicRequestTypes';
 
 class IFrameApi {
     public static run() {
@@ -15,7 +16,7 @@ class IFrameApi {
         rpcServer.init();
     }
 
-    public static async list(): Promise<WalletInfoEntry[]> {
+    public static async list(): Promise<ListResult> {
         let wallets: WalletInfoEntry[];
         if (BrowserDetection.isIOS() || BrowserDetection.isSafari()) {
             wallets = await CookieJar.eat();
@@ -23,7 +24,7 @@ class IFrameApi {
             wallets = await WalletStore.Instance.list();
         }
         if (wallets.length > 0) {
-            return wallets;
+            return wallets.map((wallet) => WalletInfo.fromObject(wallet).toAccountType());
         }
 
         // If no wallets exist, see if the Keyguard has keys

--- a/src/iframe.ts
+++ b/src/iframe.ts
@@ -24,7 +24,7 @@ class IFrameApi {
             wallets = await WalletStore.Instance.list();
         }
         if (wallets.length > 0) {
-            return wallets.map((wallet) => WalletInfo.fromObject(wallet).toAccountType());
+            return wallets.map((wallet) => WalletInfo.objectToAccountType(wallet));
         }
 
         // If no wallets exist, see if the Keyguard has keys

--- a/src/lib/AccountInfo.ts
+++ b/src/lib/AccountInfo.ts
@@ -1,4 +1,5 @@
 import { Address } from './PublicRequestTypes';
+import AddressUtils from './AddressUtils';
 
 export class AccountInfo {
     public static fromObject(o: AccountInfoEntry): AccountInfo {
@@ -8,6 +9,13 @@ export class AccountInfo {
             new Nimiq.Address(o.address),
             o.balance,
         );
+    }
+
+    public static objectToAddressType(o: AccountInfoEntry): Address {
+        return {
+            address: AddressUtils.toUserFriendlyAddress(o.address),
+            label: o.label,
+        };
     }
 
     public walletId?: string;

--- a/src/lib/ContractInfo.ts
+++ b/src/lib/ContractInfo.ts
@@ -13,6 +13,7 @@ export class ContractInfoHelper {
         }
     }
 
+    // Used in iframe
     public static objectToContractType(o: ContractInfoEntry): VestingContract | HashedTimeLockedContract {
         switch (o.type) {
             case 1 /* Nimiq.Account.Type.VESTING */:
@@ -39,9 +40,10 @@ export class VestingContractInfo {
         );
     }
 
+    // Used in iframe
     public static objectToContractType(o: VestingContractInfoEntry): VestingContract {
         return {
-            type: o.type,
+            type: 1 /* Nimiq.Account.Type.VESTING */,
             label: o.label,
             address: AddressUtils.toUserFriendlyAddress(o.address),
             owner: AddressUtils.toUserFriendlyAddress(o.owner),
@@ -152,9 +154,10 @@ export class HashedTimeLockedContractInfo {
         );
     }
 
+    // Used in iframe
     public static objectToContractType(o: HashedTimeLockedContractInfoEntry): HashedTimeLockedContract {
         return {
-            type: Nimiq.Account.Type.HTLC,
+            type: 2 /* Nimiq.Account.Type.HTLC */,
             label: o.label,
             address: AddressUtils.toUserFriendlyAddress(o.address),
             sender: AddressUtils.toUserFriendlyAddress(o.sender),

--- a/src/lib/ContractInfo.ts
+++ b/src/lib/ContractInfo.ts
@@ -1,4 +1,5 @@
 import { VestingContract, HashedTimeLockedContract, Contract } from './PublicRequestTypes';
+import AddressUtils from './AddressUtils';
 
 export class ContractInfoHelper {
     public static fromObject(o: ContractInfoEntry): VestingContractInfo | HashedTimeLockedContractInfo {
@@ -7,6 +8,17 @@ export class ContractInfoHelper {
                 return VestingContractInfo.fromObject(o);
             case Nimiq.Account.Type.HTLC:
                 return HashedTimeLockedContractInfo.fromObject(o);
+            // @ts-ignore Property 'type' does not exist on type 'never'.
+            default: throw new Error('Unknown contract type: ' + o.type);
+        }
+    }
+
+    public static objectToContractType(o: ContractInfoEntry): VestingContract | HashedTimeLockedContract {
+        switch (o.type) {
+            case 1 /* Nimiq.Account.Type.VESTING */:
+                return VestingContractInfo.objectToContractType(o);
+            case 2 /* Nimiq.Account.Type.HTLC */:
+                return HashedTimeLockedContractInfo.objectToContractType(o);
             // @ts-ignore Property 'type' does not exist on type 'never'.
             default: throw new Error('Unknown contract type: ' + o.type);
         }
@@ -25,6 +37,19 @@ export class VestingContractInfo {
             o.totalAmount,
             o.balance,
         );
+    }
+
+    public static objectToContractType(o: VestingContractInfoEntry): VestingContract {
+        return {
+            type: o.type,
+            label: o.label,
+            address: AddressUtils.toUserFriendlyAddress(o.address),
+            owner: AddressUtils.toUserFriendlyAddress(o.owner),
+            start: o.start,
+            stepAmount: o.stepAmount,
+            stepBlocks: o.stepBlocks,
+            totalAmount: o.totalAmount,
+        };
     }
 
     public type = Nimiq.Account.Type.VESTING;
@@ -125,6 +150,23 @@ export class HashedTimeLockedContractInfo {
             o.totalAmount,
             o.balance,
         );
+    }
+
+    public static objectToContractType(o: HashedTimeLockedContractInfoEntry): HashedTimeLockedContract {
+        return {
+            type: Nimiq.Account.Type.HTLC,
+            label: o.label,
+            address: AddressUtils.toUserFriendlyAddress(o.address),
+            sender: AddressUtils.toUserFriendlyAddress(o.sender),
+            recipient: AddressUtils.toUserFriendlyAddress(o.recipient),
+            hashRoot: Array.from(o.hashRoot).map((byte) => {
+                const hex = byte.toString(16);
+                return `${hex.length < 2 ? '0' : ''}${hex}`;
+            }).join(''),
+            hashCount: o.hashCount,
+            timeout: o.timeout,
+            totalAmount: o.totalAmount,
+        };
     }
 
     public type = Nimiq.Account.Type.HTLC;

--- a/src/lib/CookieDecoder.ts
+++ b/src/lib/CookieDecoder.ts
@@ -169,7 +169,8 @@ export class CookieDecoder {
         const labelBytes = this.readBytes(bytes, labelLength);
 
         // Account address
-        const addressBytes = this.readBytes(bytes, Nimiq.Address.SERIALIZED_SIZE);
+        // (iframe does not have Nimiq lib)
+        const addressBytes = this.readBytes(bytes, 20 /* Nimiq.Address.SERIALIZED_SIZE */);
 
         const accountLabel = labelBytes.length > 0
             ? Utf8Tools.utf8ByteArrayToString(new Uint8Array(labelBytes))
@@ -204,14 +205,15 @@ export class CookieDecoder {
         const labelBytes = this.readBytes(bytes, labelLength);
 
         // Contract address
-        const addressBytes = this.readBytes(bytes, Nimiq.Address.SERIALIZED_SIZE);
+        // (iframe does not have Nimiq lib)
+        const addressBytes = this.readBytes(bytes, 20 /* Nimiq.Address.SERIALIZED_SIZE */);
 
         switch (type) {
-            case Nimiq.Account.Type.VESTING:
+            case 1 /* Nimiq.Account.Type.VESTING */:
                 const label = labelBytes.length > 0
                     ? Utf8Tools.utf8ByteArrayToString(new Uint8Array(labelBytes))
                     : CONTRACT_DEFAULT_LABEL_VESTING;
-                const ownerBytes = this.readBytes(bytes, Nimiq.Address.SERIALIZED_SIZE);
+                const ownerBytes = this.readBytes(bytes, 20 /* Nimiq.Address.SERIALIZED_SIZE */);
                 const start = this.fromBase256(this.readBytes(bytes, 4)); // Uint32
                 const stepAmount = this.fromBase256(this.readBytes(bytes, 8)); // Uint64
                 const stepBlocks = this.fromBase256(this.readBytes(bytes, 4)); // Uint32
@@ -226,7 +228,7 @@ export class CookieDecoder {
                     stepBlocks,
                     totalAmount,
                 } as VestingContractInfoEntry;
-            case Nimiq.Account.Type.HTLC:
+            case 2 /* Nimiq.Account.Type.HTLC */:
                 throw new Error('HTLC decoding is not yet implemented');
             default:
                 throw new Error('Unknown contract type: ' + type);

--- a/src/lib/CookieDecoder.ts
+++ b/src/lib/CookieDecoder.ts
@@ -169,8 +169,7 @@ export class CookieDecoder {
         const labelBytes = this.readBytes(bytes, labelLength);
 
         // Account address
-        // (iframe does not have Nimiq lib)
-        const addressBytes = this.readBytes(bytes, 20 /* Nimiq.Address.SERIALIZED_SIZE */);
+        const addressBytes = this.readBytes(bytes, Nimiq.Address.SERIALIZED_SIZE);
 
         const accountLabel = labelBytes.length > 0
             ? Utf8Tools.utf8ByteArrayToString(new Uint8Array(labelBytes))

--- a/src/lib/PublicRequestTypes.ts
+++ b/src/lib/PublicRequestTypes.ts
@@ -12,7 +12,7 @@ export interface SimpleResult {
     success: true;
 }
 
-export type ListResult = WalletInfoEntry[];
+export type ListResult = Account[];
 
 export interface SignTransactionRequest extends SimpleRequest {
     sender: string;

--- a/src/lib/WalletInfo.ts
+++ b/src/lib/WalletInfo.ts
@@ -23,6 +23,18 @@ export class WalletInfo {
             o.keyMissing, o.fileExported, o.wordsExported);
     }
 
+    public static objectToAccountType(o: WalletInfoEntry): Account {
+        return {
+            accountId: o.id,
+            label: o.label,
+            type: o.type,
+            fileExported: o.fileExported,
+            wordsExported: o.wordsExported,
+            addresses: Array.from(o.accounts.values()).map((address) => AccountInfo.objectToAddressType(address)),
+            contracts: o.contracts.map((contract) => ContractInfoHelper.objectToContractType(contract)),
+        };
+    }
+
     public constructor(public id: string,
                        public label: string,
                        public accounts: Map</*address*/ string, AccountInfo>,

--- a/src/lib/WalletInfo.ts
+++ b/src/lib/WalletInfo.ts
@@ -4,6 +4,7 @@ import {
     ContractInfoEntry,
     ContractInfoHelper,
 } from './ContractInfo';
+import { Account } from './PublicRequestTypes';
 
 export enum WalletType {
     LEGACY = 1,
@@ -73,6 +74,18 @@ export class WalletInfo {
             keyMissing: this.keyMissing,
             fileExported: this.fileExported,
             wordsExported: this.wordsExported,
+        };
+    }
+
+    public toAccountType(): Account {
+        return {
+            accountId: this.id,
+            label: this.label,
+            type: this.type,
+            fileExported: this.fileExported,
+            wordsExported: this.wordsExported,
+            addresses: Array.from(this.accounts.values()).map((address) => address.toAddressType()),
+            contracts: this.contracts.map((contract) => contract.toContractType()),
         };
     }
 }

--- a/src/views/Migrate.vue
+++ b/src/views/Migrate.vue
@@ -95,8 +95,8 @@ export default class Migrate extends Vue {
 
         this.title = 'Migration completed.';
         this.state = Loader.State.SUCCESS;
-        const walletInfoEntries = walletInfos.map((walletInfo) => walletInfo.toObject());
-        setTimeout(() => this.$rpc.resolve(walletInfoEntries), Loader.SUCCESS_REDIRECT_DELAY);
+        const listResult = walletInfos.map((walletInfo) => walletInfo.toAccountType());
+        setTimeout(() => this.$rpc.resolve(listResult), Loader.SUCCESS_REDIRECT_DELAY);
     }
 
     private onError(error: Error) {


### PR DESCRIPTION
Instead of `WalletInfoEntry`, output the public `Account` type (as array) for `list()` and `migrate()` methods (latter of which results is currently not used in Safe, as migration is done via redirect and the new list of accounts is loaded with list() on return page load).

This is required, as the `WalletInfoEntry` does not contain contracts' user-friendly address anywhere, only addresses in serialized form (the addresses are a map with the user-friendly address as key, but the contracts are not). Because we have no serialized-to-user-friendly-address methods in the Safe (no Nimiq lib, and I also don't want to add a helper for this), we need another result type for contracts.

It was thus fitting to change the whole result to the public result type also returned by `signup()` and `login()` etc.

Adaptions for the Safe are in https://github.com/nimiq/safe/pull/81.