### PR TITLE
Rework message signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,8 +570,8 @@ blockchain-related proofs which could be used to impersonate them, the
 Nimiq Keyguard prefixes additional data to the message before signing.
 This prefix consists of
 
-- 1 byte length of the prefix (`22`)
-- a 22 bytes prefix (`'Nimiq Signed Message:\n'`)
+- 1 byte length of the prefix (`22` or `0x16`)
+- a 22 bytes prefix (`'Nimiq Signed Message:\n'`, available as `AccountsClient.MSG_PREFIX`)
 - the length of the message as a stringified number
 
 This data is then hashed with SHA256 before being signed. Together, this leads
@@ -588,7 +588,10 @@ const signature = new Nimiq.Signature(signedMessage.signature);
 const publicKey = new Nimiq.PublicKey(signedMessage.signerPublicKey);
 
 // For string messages:
-const data = '\x16' + 'Nimiq Signed Message:\n' + message.length + message;
+const data = String.fromCharCode(AccountsClient.MSG_PREFIX.length)
+           + AccountsClient.MSG_PREFIX
+           + message.length
+           + message;
 const dataBytes = Nimiq.BufferUtils.fromUtf8(data);
 const hash = Nimiq.Hash.computeSha256(dataBytes);
 

--- a/README.md
+++ b/README.md
@@ -562,16 +562,24 @@ interface SignedMessage {
     signer: string;               // Userfriendly address
     signerPublicKey: Uint8Array;  // The public key of the signer
     signature: Uint8Array;        // Signature for the message
-    message: string | Uint8Array; // The signed message (as the same type as it
-                                  // was handed in)
 }
 ```
 
 **Note:** To prevent users from signing valid transactions or other
-blockchain-related proofs which could be used to impersonate them, the Nimiq
-Keyguard prefixes the string `'Nimiq Signed Message: '` (22 one-byte-characters)
-to the input message. The signature is then created over the combined message.
-The prefix is already included in the result's `message` property.
+blockchain-related proofs which could be used to impersonate them, the
+Nimiq Keyguard prefixes additional data to the message before signing.
+This prefix consists of
+
+- 1 byte length of the prefix (`22`)
+- a 22 bytes prefix (`'Nimiq Signed Message:\n'`)
+- the length of the message as a stringified number
+
+This data is then hashed with SHA256 before being signed. Together, this leads
+to the following data structure:
+
+```javascript
+sign( sha256( '\x16' + 'Nimiq Signed Message:\n' + message.length + message ) );
+```
 
 Verifying a signed message could go like this:
 
@@ -579,12 +587,13 @@ Verifying a signed message could go like this:
 const signature = new Nimiq.Signature(signedMessage.signature);
 const publicKey = new Nimiq.PublicKey(signedMessage.signerPublicKey);
 
-const message = typeof signedMessage.message === 'string'
-    ? Nimiq.BufferUtils.fromUtf8(signedMessage.message))
-    : signedMessage.message;
+// For string messages:
+const data = '\x16' + 'Nimiq Signed Message:\n' + message.length + message;
+const dataBytes = Nimiq.BufferUtils.fromUtf8(data);
+const hash = Nimiq.Hash.computeSha256(dataBytes);
 
-// Check signature against the message
-const isValid = signature.verify(publicKey, message);
+// Check signature against the hashed message
+const isValid = signature.verify(publicKey, hash);
 ```
 
 ### Listening for redirect responses

--- a/client/AccountsClient.ts
+++ b/client/AccountsClient.ts
@@ -22,10 +22,12 @@ import {
     ListResult,
     RpcResult,
 } from '../src/lib/PublicRequestTypes';
+import { MSG_PREFIX } from '@nimiq/keyguard-client';
 
 export default class AccountsClient {
     public static readonly RequestType: typeof RequestType = RequestType;
     public static readonly RedirectRequestBehavior: typeof RedirectRequestBehavior = RedirectRequestBehavior;
+    public static readonly MSG_PREFIX: string = MSG_PREFIX;
 
     private static get DEFAULT_ENDPOINT() {
         const originArray = location.origin.split('.');

--- a/client/AccountsClient.ts
+++ b/client/AccountsClient.ts
@@ -22,12 +22,11 @@ import {
     ListResult,
     RpcResult,
 } from '../src/lib/PublicRequestTypes';
-import { MSG_PREFIX } from '@nimiq/keyguard-client';
 
 export default class AccountsClient {
     public static readonly RequestType: typeof RequestType = RequestType;
     public static readonly RedirectRequestBehavior: typeof RedirectRequestBehavior = RedirectRequestBehavior;
-    public static readonly MSG_PREFIX: string = MSG_PREFIX;
+    public static readonly MSG_PREFIX: string = 'Nimiq Signed Message:\n';
 
     private static get DEFAULT_ENDPOINT() {
         const originArray = location.origin.split('.');

--- a/demos/Demo.ts
+++ b/demos/Demo.ts
@@ -1,5 +1,3 @@
-/// <reference path="../node_modules/@nimiq/core-types/Nimiq.d.ts" />
-
 import { State, PostMessageRpcClient } from '@nimiq/rpc';
 import AccountsClient from '../client/AccountsClient';
 import { RequestType } from '../src/lib/RequestTypes';
@@ -21,6 +19,8 @@ class Demo {
             ? 'https://keyguard.nimiq-testnet.com'
             : `${location.protocol}//${location.hostname}:8000`;
         const demo = new Demo(keyguardOrigin);
+        // @ts-ignore (Property 'demo' does not exist on type 'Window')
+        window.demo = demo;
 
         const client = new AccountsClient(location.origin);
 
@@ -170,7 +170,7 @@ class Demo {
             try {
                 const result = await client.signMessage(request);
                 console.log('Keyguard result', result);
-                document.querySelector('#result').textContent = 'MSG signed: ' + result.message;
+                document.querySelector('#result').textContent = 'MSG signed: ' + request.message;
             } catch (e) {
                 console.error('Keyguard error', e);
                 document.querySelector('#result').textContent = `Error: ${e.message || e}`;
@@ -192,7 +192,7 @@ class Demo {
             try {
                 const result = await client.signMessage(request);
                 console.log('Keyguard result', result);
-                document.querySelector('#result').textContent = 'MSG signed: ' + result.message;
+                document.querySelector('#result').textContent = 'MSG signed: ' + request.message;
             } catch (e) {
                 console.error('Keyguard error', e);
                 document.querySelector('#result').textContent = `Error: ${e.message || e}`;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     },
     "dependencies": {
         "@nimiq/iqons": "^1.4.2",
-        "@nimiq/keyguard-client": "^0.2.8",
+        "@nimiq/keyguard-client": "^0.3.0-beta.1",
         "@nimiq/ledgerjs": "https://github.com/nimiq/ledger-api.git",
         "@nimiq/network-client": "^0.2.0",
         "@nimiq/rpc": "^0.1.4",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     },
     "dependencies": {
         "@nimiq/iqons": "^1.4.2",
-        "@nimiq/keyguard-client": "^0.3.0-beta.1",
+        "@nimiq/keyguard-client": "^0.3.0-beta.2",
         "@nimiq/ledgerjs": "https://github.com/nimiq/ledger-api.git",
         "@nimiq/network-client": "^0.2.0",
         "@nimiq/rpc": "^0.1.4",

--- a/src/lib/PublicRequestTypes.ts
+++ b/src/lib/PublicRequestTypes.ts
@@ -66,7 +66,6 @@ export interface SignedMessage {
     signer: string; // Userfriendly address
     signerPublicKey: Uint8Array;
     signature: Uint8Array;
-    message: string | Uint8Array;
 }
 
 export interface Address {

--- a/src/views/SignMessage.vue
+++ b/src/views/SignMessage.vue
@@ -106,7 +106,7 @@ export default class SignMessage extends Vue {
             keyId: walletInfo.id,
             keyPath: accountInfo.path,
 
-            message: this.messageBytes(),
+            message: this.request.message,
 
             signer: accountInfo.address.serialize(),
             signerLabel: accountInfo.label,
@@ -116,13 +116,6 @@ export default class SignMessage extends Vue {
 
         const client = this.$rpc.createKeyguardClient();
         client.signMessage(request);
-    }
-
-    private messageBytes(): Uint8Array {
-        if (typeof this.request.message === 'string') {
-            return Utf8Tools.stringToUtf8ByteArray(this.request.message);
-        }
-        return new Uint8Array(this.request.message);
     }
 
     private goToOnboarding(useReplace?: boolean) {

--- a/src/views/SignMessageSuccess.vue
+++ b/src/views/SignMessageSuccess.vue
@@ -25,7 +25,7 @@ import { SmallPage } from '@nimiq/vue-components';
 export default class SignMessageSuccess extends Vue {
     @Static private request!: ParsedSignMessageRequest;
     @Static private keyguardRequest!: KeyguardClient.SignMessageRequest;
-    @State private keyguardResult!: KeyguardClient.SignMessageResult;
+    @State private keyguardResult!: KeyguardClient.SignatureResult;
 
     private mounted() {
         const result: SignedMessage = {

--- a/src/views/SignMessageSuccess.vue
+++ b/src/views/SignMessageSuccess.vue
@@ -20,7 +20,6 @@ import KeyguardClient from '@nimiq/keyguard-client';
 import { Static } from '@/lib/StaticStore';
 import Loader from '../components/Loader.vue';
 import { SmallPage } from '@nimiq/vue-components';
-import { Utf8Tools } from '@nimiq/utils';
 
 @Component({components: {Loader, SmallPage}})
 export default class SignMessageSuccess extends Vue {
@@ -33,9 +32,6 @@ export default class SignMessageSuccess extends Vue {
             signer: new Nimiq.Address(this.keyguardRequest.signer).toUserFriendlyAddress(),
             signerPublicKey: this.keyguardResult.publicKey,
             signature: this.keyguardResult.signature,
-            message: typeof this.request.message === 'string'
-                ? Utf8Tools.utf8ByteArrayToString(this.keyguardResult.data)
-                : this.keyguardResult.data,
         };
 
         setTimeout(() => this.$rpc.resolve(result), Loader.SUCCESS_REDIRECT_DELAY);

--- a/tests/unit/AccountsClient.spec.ts
+++ b/tests/unit/AccountsClient.spec.ts
@@ -1,0 +1,9 @@
+import AccountsClient from '../../client/AccountsClient';
+import * as KeyguardClient from '@nimiq/keyguard-client';
+
+describe('AccountsClient', () => {
+    it('exports the correct MSG_PREFIX', () => {
+        expect(AccountsClient.MSG_PREFIX).toEqual(KeyguardClient.MSG_PREFIX);
+    });
+});
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -727,10 +727,10 @@
     levelup "^2.0.2"
     node-lmdb "0.6.0"
 
-"@nimiq/keyguard-client@^0.3.0-beta.1":
-  version "0.3.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@nimiq/keyguard-client/-/keyguard-client-0.3.0-beta.1.tgz#39096951f7d337727fdcdc415d9eddda713b2d73"
-  integrity sha512-XxUxcUO1QPM1MeTVF4SNj7X6WxFxKftZX0zvpF4lWz9rHEmre2LludwN52Q9QfaAjcYKJNOERM4wPjA4WSFBsw==
+"@nimiq/keyguard-client@^0.3.0-beta.2":
+  version "0.3.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@nimiq/keyguard-client/-/keyguard-client-0.3.0-beta.2.tgz#1724b7ba99f1530a4c36d1a41e4c8d82c11353c7"
+  integrity sha512-23XWA6S5fM6SVeJg160XMKhwDiSb/XysRVQ4aFhyt9uY7ZycOxzSIkkqEcamzOIlDFCp6ixrcLYqbtebDoO33A==
   dependencies:
     "@nimiq/core-web" "1.4.3"
     "@nimiq/rpc" "^0.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -727,10 +727,10 @@
     levelup "^2.0.2"
     node-lmdb "0.6.0"
 
-"@nimiq/keyguard-client@^0.2.8":
-  version "0.2.8"
-  resolved "https://registry.yarnpkg.com/@nimiq/keyguard-client/-/keyguard-client-0.2.8.tgz#ac4ea3fb5e95e3524ec2107545ea15695c7f0ff1"
-  integrity sha512-Ftg5423AK7nfDDuuQw/nVOfKGqcRxcBjBS9z1kc/MGFIuZuA0f2onSS5Pn1xLdjMkQoJrf3c0YQASCSK29UJzw==
+"@nimiq/keyguard-client@^0.3.0-beta.1":
+  version "0.3.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@nimiq/keyguard-client/-/keyguard-client-0.3.0-beta.1.tgz#39096951f7d337727fdcdc415d9eddda713b2d73"
+  integrity sha512-XxUxcUO1QPM1MeTVF4SNj7X6WxFxKftZX0zvpF4lWz9rHEmre2LludwN52Q9QfaAjcYKJNOERM4wPjA4WSFBsw==
   dependencies:
     "@nimiq/core-web" "1.4.3"
     "@nimiq/rpc" "^0.1.4"


### PR DESCRIPTION
- Forward message as-is to Keyguard
- Do not return signed data from signMessage
- Export message prefix in client
- Update docs for reworked signature validation

To use with https://github.com/nimiq/keyguard-next/pull/256.