### PR TITLE
Make clone URL work for those without push access

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,7 +661,7 @@ To get started with working on the source code, pull the code and install the de
 ### Setup
 
 ```bash
-git clone git@github.com:nimiq/accounts.git
+git clone https://github.com/nimiq/accounts.git
 cd accounts
 yarn
 ```


### PR DESCRIPTION
SSH URLs only work for those with push access to this repo, HTTPS urls work for everyone.