### PR TITLE
Hide contracts in signMessage

### DIFF
--- a/src/views/SignMessage.vue
+++ b/src/views/SignMessage.vue
@@ -9,10 +9,10 @@
                 <span class="origin">{{ originDomain }}</span>
             </div>
 
-            <h1 class="nq-h1">Choose an account to sign</h1>
+            <h1 class="nq-h1">Choose an address to sign</h1>
 
             <AccountSelector
-                :wallets="processedWallets"
+                :wallets="processedWallets | withoutContracts"
                 @account-selected="setAccount"
                 @login="goToOnboarding"/>
         </SmallPage>
@@ -39,7 +39,17 @@ import { Utf8Tools } from '@nimiq/utils';
 import { ERROR_CANCELED } from '@/lib/Constants';
 import { State as RpcState } from '@nimiq/rpc';
 
-@Component({components: {SmallPage, AccountSelector}})
+@Component({
+    components: {SmallPage, AccountSelector},
+    filters: {
+        withoutContracts(wallets: WalletInfo[]): WalletInfo[] {
+            return wallets.map((wallet) => {
+                wallet.contracts = [];
+                return wallet;
+            });
+        },
+    },
+})
 export default class SignMessage extends Vue {
     @Static protected request!: ParsedSignMessageRequest;
     @Static private rpcState!: RpcState;


### PR DESCRIPTION
Add a filter to remove contracts from `processedWallets`.

Also fix wording from 'account' to 'address'.