### PR TITLE
Allow passing a sender to checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,22 @@ const requestOptions = {
     // Default: new Uint8Array(0)
     //extraData: 'Hello Nimiq!',
 
+    // [optional] Human-readable address of the sender.
+    // If the address exists in the user's Accounts Manager, this parameter
+    // forwards the user directly to the transaction-signing after the
+    // balance check.
+    // Default: undefined
+    //sender: 'NQ07 0000 0000 0000 0000 0000 0000 0000 0000',
+
+    // [optional] Whether to force the submitted sender address
+    // If this parameter is true, an exception is thrown when either the
+    // submitted sender address does not exist or does not have sufficient
+    // balance. When false, the user will be shown the address selector
+    // for the above conditions instead.
+    // (Only relevant in connection with the `sender` parameter)
+    // Default: false
+    //forceSender: true,
+
     // [optional] Nimiq.Transaction.Flag, only required if the transaction
     // creates a contract.
     // Default: Nimiq.Transaction.Flag.NONE (0)

--- a/demos/Demo.ts
+++ b/demos/Demo.ts
@@ -57,6 +57,10 @@ class Demo {
             await checkoutPopup(await generateCheckoutRequest(demo));
         });
 
+        document.querySelector('button#checkout-popup-with-account').addEventListener('click', async () => {
+            await checkoutPopup(await generateCheckoutRequest(demo, true));
+        });
+
         document.querySelector('button#choose-address').addEventListener('click', async () => {
             try {
                 const result = await client.chooseAddress({ appName: 'Accounts Demos' });
@@ -136,16 +140,23 @@ class Demo {
             };
         }
 
-        async function generateCheckoutRequest(demo: Demo): Promise<CheckoutRequest> {
+        async function generateCheckoutRequest(demo: Demo, useSelectedAddress: boolean): Promise<CheckoutRequest> {
             const value = parseInt((document.querySelector('#value') as HTMLInputElement).value) || 1337;
             const txFee = parseInt((document.querySelector('#fee') as HTMLInputElement).value) || 0;
             const txData = (document.querySelector('#data') as HTMLInputElement).value || '';
+            const $radio = document.querySelector('input[type="radio"]:checked');
+            if (!$radio) {
+                alert('You have no account to send a tx from, create an account first (signup)');
+                throw new Error('No account found');
+            }
+            const sender = $radio.getAttribute('data-address');
+            const forceSender = (document.getElementById('checkout-force-sender') as HTMLInputElement).checked;
 
             return {
                 appName: 'Accounts Demos',
                 shopLogoUrl: `${location.origin}/nimiq.png`,
-                // sender: 'NQ74 X5AS 50F2 X2U8 SK5C 5XML TKDH AA48 GE6A',
-                // forceSender: true,
+                sender: useSelectedAddress ? sender : undefined,
+                forceSender,
                 recipient: 'NQ63 U7XG 1YYE D6FA SXGG 3F5H X403 NBKN JLDU',
                 value,
                 fee: txFee,

--- a/demos/Demo.ts
+++ b/demos/Demo.ts
@@ -144,6 +144,8 @@ class Demo {
             return {
                 appName: 'Accounts Demos',
                 shopLogoUrl: `${location.origin}/nimiq.png`,
+                // sender: 'NQ74 X5AS 50F2 X2U8 SK5C 5XML TKDH AA48 GE6A',
+                // forceSender: true,
                 recipient: 'NQ63 U7XG 1YYE D6FA SXGG 3F5H X403 NBKN JLDU',
                 value,
                 fee: txFee,

--- a/demos/index.html
+++ b/demos/index.html
@@ -72,7 +72,7 @@
 
     <div class="row">
         <label>Transaction data (ascii)</label>
-        <input id="data" value="Thank you for shopping at shop.nimiq.com (H3XC0D)">
+        <input id="data" value="Thank you for testing Nimiq Accounts!">
     </div>
 
     <div class="row">

--- a/demos/index.html
+++ b/demos/index.html
@@ -44,7 +44,7 @@
     <button id="onboard" disabled>Onboarding Menu</button>
 
     <h2>Create</h2>
-    <button id="create" disabled>Create new wallet & account</button>
+    <button id="create" disabled>New Account</button>
 
     <h2>Login (Import)</h2>
     <button id="login" disabled>Login</button>
@@ -82,6 +82,8 @@
 
     <br><button id="checkout-redirect" disabled>Checkout (redirect)</button>
     <br><button id="checkout-popup" disabled>Checkout (popup)</button>
+    <br><button id="checkout-popup-with-account" disabled>Checkout with selected address</button>
+        <label><input type="checkbox" id="checkout-force-sender"> Force Sender</label>
     <br><button id="sign-transaction-popup" disabled>Sign Transaction</button>
 </div>
 
@@ -93,7 +95,7 @@
     </div>
 
     <br><button id="sign-message" disabled>Sign Message</button>
-    <br><button id="sign-message-with-account" disabled>Sign Message with selected Account</button>
+    <br><button id="sign-message-with-account" disabled>Sign Message with selected address</button>
 </div>
 
 <div class="request">

--- a/src/lib/PublicRequestTypes.ts
+++ b/src/lib/PublicRequestTypes.ts
@@ -28,6 +28,7 @@ export interface SignTransactionRequest extends BasicRequest {
 export interface CheckoutRequest extends BasicRequest {
     shopLogoUrl?: string;
     sender?: string;
+    forceSender?: boolean;
     recipient: string;
     recipientType?: Nimiq.Account.Type;
     value: number;

--- a/src/lib/PublicRequestTypes.ts
+++ b/src/lib/PublicRequestTypes.ts
@@ -27,6 +27,7 @@ export interface SignTransactionRequest extends BasicRequest {
 
 export interface CheckoutRequest extends BasicRequest {
     shopLogoUrl?: string;
+    sender?: string;
     recipient: string;
     recipientType?: Nimiq.Account.Type;
     value: number;

--- a/src/lib/RequestParser.ts
+++ b/src/lib/RequestParser.ts
@@ -66,6 +66,7 @@ export class RequestParser {
                     sender: checkoutRequest.sender
                         ? Nimiq.Address.fromUserFriendlyAddress(checkoutRequest.sender)
                         : undefined,
+                    forceSender: !!checkoutRequest.forceSender,
                     recipient: Nimiq.Address.fromUserFriendlyAddress(checkoutRequest.recipient),
                     recipientType: checkoutRequest.recipientType || Nimiq.Account.Type.BASIC,
                     value: checkoutRequest.value,
@@ -166,6 +167,7 @@ export class RequestParser {
                     appName: checkoutRequest.appName,
                     shopLogoUrl: checkoutRequest.shopLogoUrl,
                     sender: checkoutRequest.sender ? checkoutRequest.sender.toUserFriendlyAddress() : undefined,
+                    forceSender: checkoutRequest.forceSender,
                     recipient: checkoutRequest.recipient.toUserFriendlyAddress(),
                     recipientType: checkoutRequest.recipientType,
                     value: checkoutRequest.value,

--- a/src/lib/RequestParser.ts
+++ b/src/lib/RequestParser.ts
@@ -63,6 +63,9 @@ export class RequestParser {
                     kind: RequestType.CHECKOUT,
                     appName: checkoutRequest.appName,
                     shopLogoUrl: checkoutRequest.shopLogoUrl,
+                    sender: checkoutRequest.sender
+                        ? Nimiq.Address.fromUserFriendlyAddress(checkoutRequest.sender)
+                        : undefined,
                     recipient: Nimiq.Address.fromUserFriendlyAddress(checkoutRequest.recipient),
                     recipientType: checkoutRequest.recipientType || Nimiq.Account.Type.BASIC,
                     value: checkoutRequest.value,
@@ -162,6 +165,7 @@ export class RequestParser {
                 return {
                     appName: checkoutRequest.appName,
                     shopLogoUrl: checkoutRequest.shopLogoUrl,
+                    sender: checkoutRequest.sender ? checkoutRequest.sender.toUserFriendlyAddress() : undefined,
                     recipient: checkoutRequest.recipient.toUserFriendlyAddress(),
                     recipientType: checkoutRequest.recipientType,
                     value: checkoutRequest.value,

--- a/src/lib/RequestTypes.ts
+++ b/src/lib/RequestTypes.ts
@@ -37,6 +37,7 @@ export interface ParsedSignTransactionRequest extends ParsedBasicRequest {
 
 export interface ParsedCheckoutRequest extends ParsedBasicRequest {
     shopLogoUrl?: string;
+    sender?: Nimiq.Address;
     recipient: Nimiq.Address;
     recipientType: Nimiq.Account.Type;
     value: number;

--- a/src/lib/RequestTypes.ts
+++ b/src/lib/RequestTypes.ts
@@ -38,6 +38,7 @@ export interface ParsedSignTransactionRequest extends ParsedBasicRequest {
 export interface ParsedCheckoutRequest extends ParsedBasicRequest {
     shopLogoUrl?: string;
     sender?: Nimiq.Address;
+    forceSender: boolean;
     recipient: Nimiq.Address;
     recipientType: Nimiq.Account.Type;
     value: number;

--- a/src/store.ts
+++ b/src/store.ts
@@ -110,9 +110,9 @@ const store: StoreOptions<RootState> = {
         findWallet: (state) => (id: string): WalletInfo | undefined => {
             return state.wallets.find((wallet) => wallet.id === id);
         },
-        findWalletByAddress: (state) => (address: string): WalletInfo | undefined => {
+        findWalletByAddress: (state) => (address: string, includeContracts: boolean): WalletInfo | undefined => {
             const foundWallet = state.wallets.find((wallet) => wallet.accounts.has(address));
-            if (foundWallet) return foundWallet;
+            if (foundWallet || !includeContracts) return foundWallet;
             return state.wallets.find((wallet) => wallet.contracts.some((contract) => {
                 return contract.address.toUserFriendlyAddress() === address;
             }));

--- a/src/views/Checkout.vue
+++ b/src/views/Checkout.vue
@@ -115,7 +115,7 @@ export default class Checkout extends Vue {
             if (wallet) {
                 // Check if that address has enough balance
                 const balance = balances.get(senderAddress);
-                if (balance && balance >= this.minBalance) {
+                if (balance && Nimiq.Policy.coinsToSatoshis(balance) >= this.minBalance) {
                     // Forward to Keyguard, skipping account selection
                     this.setAccountOrContract(wallet.id, senderAddress);
                     return;

--- a/src/views/Checkout.vue
+++ b/src/views/Checkout.vue
@@ -189,7 +189,7 @@ export default class Checkout extends Vue {
             const cacheInput = {
                 timestamp: Date.now(),
                 height: this.height,
-                balances: Array.from(balances.entries());
+                balances: Array.from(balances.entries()),
             };
             window.sessionStorage.setItem(Checkout.BALANCE_CHECK_STORAGE_KEY, JSON.stringify(cacheInput));
 
@@ -316,7 +316,7 @@ export default class Checkout extends Vue {
         if (!rawCache) return null;
 
         try {
-            const cache: {timestamp: number, height: number, balances: [string, number][]} = JSON.parse(rawCache);
+            const cache: {timestamp: number, height: number, balances: Array<[string, number]>} = JSON.parse(rawCache);
 
             // Check if expired or doesn't have a height
             if (cache.timestamp < Date.now() - 5 * 60 * 1000 || cache.height === 0) throw new Error();

--- a/src/views/Checkout.vue
+++ b/src/views/Checkout.vue
@@ -25,7 +25,7 @@
 
             <AccountSelector
                 :wallets="processedWallets"
-                :minBalance="request.value + request.fee"
+                :minBalance="minBalance"
                 @account-selected="accountOrContractSelected"
                 @login="goToOnboarding"/>
 

--- a/src/views/Checkout.vue
+++ b/src/views/Checkout.vue
@@ -105,6 +105,7 @@ export default class Checkout extends Vue {
 
             // Handle optional sender address included in the request
             if (this.request.sender) {
+                let errorMsg = '';
                 // Check if the address exists
                 const wallet = this.findWalletByAddress(this.request.sender.toUserFriendlyAddress(), true);
                 if (wallet) {
@@ -115,7 +116,16 @@ export default class Checkout extends Vue {
                         // Forward to Keyguard, skipping account selection
                         this.accountOrContractSelected(wallet.id, this.request.sender.toUserFriendlyAddress());
                         return;
+                    } else {
+                        errorMsg = 'Address does not have sufficient balance';
                     }
+                } else {
+                    errorMsg = 'Address not found';
+                }
+
+                if (this.request.forceSender) {
+                    this.$rpc.reject(new Error(errorMsg));
+                    return;
                 }
             }
 

--- a/src/views/Checkout.vue
+++ b/src/views/Checkout.vue
@@ -26,7 +26,7 @@
             <AccountSelector
                 :wallets="processedWallets"
                 :minBalance="minBalance"
-                @account-selected="accountOrContractSelected"
+                @account-selected="setAccountOrContract"
                 @login="goToOnboarding"/>
 
             <transition name="account-details-fade">
@@ -114,7 +114,7 @@ export default class Checkout extends Vue {
                     const balance = balances.get(senderAddress);
                     if (balance && balance >= this.minBalance) {
                         // Forward to Keyguard, skipping account selection
-                        this.accountOrContractSelected(wallet.id, senderAddress);
+                        this.setAccountOrContract(wallet.id, senderAddress);
                         return;
                     } else {
                         errorMsg = 'Address does not have sufficient balance';
@@ -199,7 +199,7 @@ export default class Checkout extends Vue {
         this.height = head.height;
     }
 
-    private accountOrContractSelected(walletId: string, address: string) {
+    private setAccountOrContract(walletId: string, address: string) {
         if (!this.height) return; // TODO: Make it impossible for users to click when height is not ready
 
         const walletInfo = this.wallets.find((wallet: WalletInfo) => wallet.id === walletId)!;

--- a/src/views/SignMessage.vue
+++ b/src/views/SignMessage.vue
@@ -13,7 +13,7 @@
 
             <AccountSelector
                 :wallets="processedWallets | withoutContracts"
-                @account-selected="setAccount"
+                @account-selected="accountSelected"
                 @login="goToOnboarding"/>
         </SmallPage>
 
@@ -56,7 +56,7 @@ export default class SignMessage extends Vue {
 
     @Getter private processedWallets!: WalletInfo[];
     @Getter private findWallet!: (id: string) => WalletInfo | undefined;
-    @Getter private findWalletByAddress!: (address: string) => WalletInfo | undefined;
+    @Getter private findWalletByAddress!: (address: string, includeContracts: boolean) => WalletInfo | undefined;
 
     @Mutation('addWallet') private $addWallet!: (walletInfo: WalletInfo) => any;
     @Mutation('setActiveAccount') private $setActiveAccount!: (payload: {
@@ -70,9 +70,9 @@ export default class SignMessage extends Vue {
         await this.handleOnboardingResult();
 
         if (this.request.signer) {
-            const wallet = this.findWalletByAddress(this.request.signer.toUserFriendlyAddress());
+            const wallet = this.findWalletByAddress(this.request.signer.toUserFriendlyAddress(), false);
             if (wallet) {
-                this.setAccount(wallet.id, this.request.signer.toUserFriendlyAddress(), true);
+                this.accountSelected(wallet.id, this.request.signer.toUserFriendlyAddress(), true);
                 return;
             }
         }
@@ -80,7 +80,7 @@ export default class SignMessage extends Vue {
         this.showAccountSelector = true;
     }
 
-    private async setAccount(walletId: string, address: string, isFromRequest = false) {
+    private async accountSelected(walletId: string, address: string, isFromRequest = false) {
         const walletInfo = this.findWallet(walletId);
         if (!walletInfo) {
             // We can also return an error here and when checking the address below,

--- a/src/views/SignMessage.vue
+++ b/src/views/SignMessage.vue
@@ -13,7 +13,7 @@
 
             <AccountSelector
                 :wallets="processedWallets | withoutContracts"
-                @account-selected="accountSelected"
+                @account-selected="setAccount"
                 @login="goToOnboarding"/>
         </SmallPage>
 
@@ -72,7 +72,7 @@ export default class SignMessage extends Vue {
         if (this.request.signer) {
             const wallet = this.findWalletByAddress(this.request.signer.toUserFriendlyAddress(), false);
             if (wallet) {
-                this.accountSelected(wallet.id, this.request.signer.toUserFriendlyAddress(), true);
+                this.setAccount(wallet.id, this.request.signer.toUserFriendlyAddress(), true);
                 return;
             }
         }
@@ -80,7 +80,7 @@ export default class SignMessage extends Vue {
         this.showAccountSelector = true;
     }
 
-    private async accountSelected(walletId: string, address: string, isFromRequest = false) {
+    private async setAccount(walletId: string, address: string, isFromRequest = false) {
         const walletInfo = this.findWallet(walletId);
         if (!walletInfo) {
             // We can also return an error here and when checking the address below,

--- a/src/views/SignTransaction.vue
+++ b/src/views/SignTransaction.vue
@@ -13,12 +13,12 @@ import { Getter } from 'vuex-class';
 @Component
 export default class SignTransaction extends Vue {
     @Static private request!: ParsedSignTransactionRequest;
-    @Getter private findWalletByAddress!: (address: string) => WalletInfo | undefined;
+    @Getter private findWalletByAddress!: (address: string, includeContracts: boolean) => WalletInfo | undefined;
 
     public async created() {
         // Forward user through AccountsManager to Keyguard
 
-        const wallet = this.findWalletByAddress(this.request.sender.toUserFriendlyAddress());
+        const wallet = this.findWalletByAddress(this.request.sender.toUserFriendlyAddress(), true);
         if (!wallet) {
             this.$rpc.reject(new Error('Address not found'));
             return;


### PR DESCRIPTION
When the `sender` address exists and has enough balance, the user is directly forwarded to the Keyguard for signing.

When the address does either not exist or does not have sufficient balance, the user is either displayed the address selector list (default), or - in case `forceSender = true` - the request is rejected with an exception.

Resolves #212.