### PR TITLE
Handle absence of request

### DIFF
--- a/README.md
+++ b/README.md
@@ -746,6 +746,8 @@ The following values can be changed via configuration files:
 - networkEndpoint: The location of the network iframe instance you want to use.
 - privilegedOrigins: An array of origins with special access rights, nameley
   permission to use iframe methods like `list()`.
+- redirectTarget: In case of empty referrer or absence of request, the user is
+  redirected to this page.
 
 The default config file is `config.local.ts`. To use a different file
 (especially useful for deployment), set an environment variable

--- a/demos/index.html
+++ b/demos/index.html
@@ -102,6 +102,9 @@
     <h2>Migrate</h2>
     <br><button id="setup-legacy-accounts" disabled>Setup Legacy Accounts</button>
     <br><button id="migrate" disabled>Migrate Legacy Accounts</button>
+
+    <h2>No request</h2>
+    <a href="/">Go to root without request</a>
 </div>
 
 <div class="request">

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,7 +13,7 @@ module.exports = {
   },
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
-    'config': '<rootDir>/config.local.ts',
+    'config': '<rootDir>/src/config/config.local.ts',
     '@nimiq/iqons/dist/iqons-name.min.js': '@nimiq/iqons/dist/iqons-name.cjs.js',
   },
   snapshotSerializers: [

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "@nimiq/keyguard-client": "^0.4.3",
         "@nimiq/ledgerjs": "https://github.com/nimiq/ledger-api.git",
         "@nimiq/network-client": "^0.2.0",
-        "@nimiq/rpc": "^0.1.4",
+        "@nimiq/rpc": "^0.1.5",
         "@nimiq/style": "^0.6.2",
         "@nimiq/utils": "^0.3.1",
         "@nimiq/vue-components": "https://github.com/nimiq/vue-components.git#build/accounts",

--- a/src/config/config.local.ts
+++ b/src/config/config.local.ts
@@ -1,8 +1,9 @@
-import { NETWORK_TEST } from './src/lib/Constants';
+import { NETWORK_TEST } from '../lib/Constants';
 
 export default {
     keyguardEndpoint: window.location.protocol + '//' + window.location.hostname + ':8000/src',
     network: NETWORK_TEST,
     networkEndpoint: 'https://network.nimiq-testnet.com',
     privilegedOrigins: [ '*' ],
+    redirectTarget: window.location.protocol + '//' + window.location.hostname + ':8080/demos',
 };

--- a/src/config/config.mainnet.ts
+++ b/src/config/config.mainnet.ts
@@ -1,8 +1,9 @@
-import { NETWORK_MAIN } from './src/lib/Constants';
+import { NETWORK_MAIN } from '../lib/Constants';
 
 export default {
     keyguardEndpoint: 'https://keyguard.nimiq.com',
     network: NETWORK_MAIN,
     networkEndpoint: 'https://network.nimiq.com',
     privilegedOrigins: [ 'https://safe.nimiq.com' ],
+    redirectTarget: 'https://safe.nimiq.com',
 };

--- a/src/config/config.testnet.ts
+++ b/src/config/config.testnet.ts
@@ -1,8 +1,9 @@
-import { NETWORK_TEST } from './src/lib/Constants';
+import { NETWORK_TEST } from '../lib/Constants';
 
 export default {
     keyguardEndpoint: 'https://keyguard.nimiq-testnet.com',
     network: NETWORK_TEST,
     networkEndpoint: 'https://network.nimiq-testnet.com',
     privilegedOrigins: [ 'https://safe.nimiq-testnet.com' ],
+    redirectTarget: 'https://safe.nimiq-testnet.com',
 };

--- a/src/lib/RpcApi.ts
+++ b/src/lib/RpcApi.ts
@@ -58,7 +58,10 @@ export default class RpcApi {
     }
 
     public start() {
-        this._server.init();
+        // Redirect to Safe (default) if there is no client.
+        // This happens if user clicks on a link to accounts.nimiq.com.
+        const onClientTimeout = () => { location.href = Config.redirectTarget; };
+        this._server.init(onClientTimeout);
         this._keyguardClient.init().catch(console.error); // TODO: Provide better error handling here
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import router from './router';
 import store from './store';
 import staticStore from '@/lib/StaticStore';
 import RpcApi from '@/lib/RpcApi';
+import Config from 'config';
 import VueRaven from 'vue-raven'; // Sentry.io SDK
 
 // Register service worker if necessary (and possible).
@@ -13,6 +14,11 @@ if ('serviceWorker' in navigator) {
     }).then((reg) => {
         console.debug(`Service worker has been registered for scope: ${reg.scope}`);
     });
+}
+
+// Redirect to Safe (default) if referrer is empty
+if (!document.referrer) {
+    location.href = Config.redirectTarget;
 }
 
 Vue.config.productionTip = false;

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,11 +16,6 @@ if ('serviceWorker' in navigator) {
     });
 }
 
-// Redirect to Safe (default) if referrer is empty
-if (!document.referrer) {
-    location.href = Config.redirectTarget;
-}
-
 Vue.config.productionTip = false;
 
 // Set up Identicon SVG file path

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
         "src/*"
       ],
       "config": [
-        "config.local.ts"
+        "src/config/config.local.ts"
       ]
     },
     "lib": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,7 +32,6 @@
   "include": [
     "types/Nimiq.d.ts",
     "types/KeyguardRequest.d.ts",
-    "config.d.ts",
     "src/**/*.ts",
     "src/**/*.tsx",
     "src/**/*.vue",

--- a/tsconfig.local.json
+++ b/tsconfig.local.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "paths": {
       "config": [
-        "config.local.ts"
+        "src/config/config.local.ts"
       ]
     }
   }

--- a/tsconfig.mainnet.json
+++ b/tsconfig.mainnet.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "paths": {
       "config": [
-        "config.mainnet.ts"
+        "src/config/config.mainnet.ts"
       ]
     }
   }

--- a/tsconfig.testnet.json
+++ b/tsconfig.testnet.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "paths": {
       "config": [
-        "config.testnet.ts"
+        "src/config/config.testnet.ts"
       ]
     }
   }

--- a/vue.config.js
+++ b/vue.config.js
@@ -18,7 +18,7 @@ const configureWebpack = {
     // Resolve config for yarn build
     resolve: {
         alias: {
-            config: path.join(__dirname, `config.${buildName}.ts`)
+            config: path.join(__dirname, `src/config/config.${buildName}.ts`)
         }
     },
     // Fix sourcemaps (https://www.mistergoodcat.com/post/the-joy-that-is-source-maps-with-vuejs-and-typescript)

--- a/yarn.lock
+++ b/yarn.lock
@@ -759,6 +759,11 @@
   resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.1.4.tgz#ff6608255f23bb80079e10b23b7b74c35190e9da"
   integrity sha512-vKU8zw8aHabGBaRTvf31MeVaByhkEChkdlx6IYw555XH5TitYQO6XYfTpoDelXUOG/xX4BQrCMV6NnLKY5yN0Q==
 
+"@nimiq/rpc@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.1.5.tgz#53919b0a3a9abcdfebee0e865f4c663f72a8b8c2"
+  integrity sha512-oTRThXzpbQOY8jz8h+2KXucWzW40nVfYBWROKXKBrSozhTG0nR+rzCbEm4ZyTC26b4RnmB6y4nYabUXi7gNWcA==
+
 "@nimiq/style@^0.6.0", "@nimiq/style@^0.6.2":
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/@nimiq/style/-/style-0.6.2.tgz#dee970c69a53fc3bf95a7f1fe0b656d4e94b897b"


### PR DESCRIPTION
Introduces a new config parameter `redirectTarget`, where the user is redirected if the rpc server doesn't receive a request. Needs https://github.com/nimiq/rpc/pull/17 to be merged and released first.

I also moved the config files from root to `src/config` to emphasise that they take effect at build-time and not at run-time and to be consistent with keyguard.