### PR TITLE
Enable automatic Account retrieval in case login returns multiple Accounts

### DIFF
--- a/client/AccountsClient.ts
+++ b/client/AccountsClient.ts
@@ -20,7 +20,6 @@ import {
     SimpleResult,
     ExportRequest,
     ExportResult,
-    ListResult,
     RpcResult,
 } from '../src/lib/PublicRequestTypes';
 
@@ -83,7 +82,7 @@ export default class AccountsClient {
         return this._request(requestBehavior, RequestType.SIGNUP, [request]);
     }
 
-    public login(request: BasicRequest, requestBehavior = this._defaultBehavior): Promise<Account> {
+    public login(request: BasicRequest, requestBehavior = this._defaultBehavior): Promise<Account[]> {
         return this._request(requestBehavior, RequestType.LOGIN, [request]);
     }
 
@@ -136,14 +135,14 @@ export default class AccountsClient {
         return this._request(requestBehavior, RequestType.SIGN_MESSAGE, [request]);
     }
 
-    public migrate(requestBehavior = this._defaultBehavior): Promise<ListResult> {
+    public migrate(requestBehavior = this._defaultBehavior): Promise<Account[]> {
         return this._request(requestBehavior, RequestType.MIGRATE, [{ appName: 'Accounts Client' }]);
     }
 
     /**
      * Only accessible in iframe from Nimiq domains.
      */
-    public list(requestBehavior = this._iframeBehavior): Promise<ListResult> {
+    public list(requestBehavior = this._iframeBehavior): Promise<Account[]> {
         return this._request(requestBehavior, RequestType.LIST, []);
     }
 

--- a/src/iframe.ts
+++ b/src/iframe.ts
@@ -4,7 +4,7 @@ import { WalletStore } from '@/lib/WalletStore';
 import { WalletInfoEntry, WalletInfo } from '@/lib/WalletInfo';
 import CookieJar from '@/lib/CookieJar';
 import Config from 'config';
-import { ListResult } from './lib/PublicRequestTypes';
+import { Account } from './lib/PublicRequestTypes';
 
 class IFrameApi {
     public static run() {
@@ -16,7 +16,7 @@ class IFrameApi {
         rpcServer.init();
     }
 
-    public static async list(): Promise<ListResult> {
+    public static async list(): Promise<Account[]> {
         let wallets: WalletInfoEntry[];
         if (BrowserDetection.isIOS() || BrowserDetection.isSafari()) {
             wallets = await CookieJar.eat();

--- a/src/lib/PublicRequestTypes.ts
+++ b/src/lib/PublicRequestTypes.ts
@@ -12,8 +12,6 @@ export interface SimpleResult {
     success: true;
 }
 
-export type ListResult = Account[];
-
 export interface SignTransactionRequest extends BasicRequest {
     sender: string;
     recipient: string;
@@ -136,8 +134,8 @@ export type RpcRequest = SignTransactionRequest
 
 export type RpcResult = SignedTransaction
                       | Account
+                      | Account[]
                       | SimpleResult
                       | Address
                       | SignedMessage
-                      | ListResult
                       | ExportResult;

--- a/src/lib/WalletInfoCollector.ts
+++ b/src/lib/WalletInfoCollector.ts
@@ -34,6 +34,7 @@ export default class WalletInfoCollector {
         initialAccounts: BasicAccountInfo[] = [],
         // tslint:disable-next-line:no-empty
         onUpdate: (walletInfo: WalletInfo, currentlyCheckedAccounts: BasicAccountInfo[]) => void = () => {},
+        // TODO onDelete callback
     ): Promise<WalletCollectionResult> {
         // Kick off loading dependencies
         WalletInfoCollector._initializeDependencies(walletType);
@@ -85,6 +86,9 @@ export default class WalletInfoCollector {
         if (walletType === WalletType.LEGACY) {
             // legacy wallets have no derived accounts
             await initialAccountsPromise;
+
+            // TODO await onDelete callback and release key
+
             return { walletInfo };
         }
 
@@ -154,6 +158,9 @@ export default class WalletInfoCollector {
 
         // clean up
         if (walletType === WalletType.BIP39 && WalletInfoCollector._keyguardClient) {
+
+            // TODO await onDelete callback and set shouldBeRemoved flag
+
             WalletInfoCollector._keyguardClient.releaseKey(keyId);
         } else if (walletType === WalletType.LEDGER && LedgerApi.currentRequest
             && LedgerApi.currentRequest.type === LedgerApi.RequestType.DERIVE_ACCOUNTS) {

--- a/src/views/LoginSuccess.vue
+++ b/src/views/LoginSuccess.vue
@@ -36,7 +36,7 @@ export default class LoginSuccess extends Vue {
     private state: Loader.State = Loader.State.LOADING;
     private title: string = 'Collecting your addresses';
     private receiptsError: Error | null = null;
-    private result: Account | null = null;
+    private result: Account[] | null = null;
 
     private async mounted() {
         // TODO: Handle import of both a legacy and bip39 key!
@@ -80,7 +80,7 @@ export default class LoginSuccess extends Vue {
 
     private done() {
         if (!this.walletInfos.length) throw new Error('WalletInfo not ready.');
-        this.result = {
+        this.result = [{
             accountId: this.walletInfos[0].id,
             label: this.walletInfos[0].label,
             type: this.walletInfos[0].type,
@@ -89,7 +89,7 @@ export default class LoginSuccess extends Vue {
             addresses: Array.from(this.walletInfos[0].accounts.values())
                 .map((addressInfo) => addressInfo.toAddressType()),
             contracts: this.walletInfos[0].contracts.map((contract) => contract.toContractType()),
-        };
+        }];
 
         if (this.receiptsError) {
             this.title = 'Your addresses may be\nincomplete.';

--- a/src/views/LoginSuccess.vue
+++ b/src/views/LoginSuccess.vue
@@ -18,13 +18,14 @@ import { Component, Vue } from 'vue-property-decorator';
 import { ParsedBasicRequest } from '../lib/RequestTypes';
 import { Account } from '../lib/PublicRequestTypes';
 import { State } from 'vuex-class';
-import { WalletInfo } from '../lib/WalletInfo';
+import { WalletInfo, WalletInfoEntry, WalletType } from '../lib/WalletInfo';
 import { WalletStore } from '@/lib/WalletStore';
 import { Static } from '@/lib/StaticStore';
 import { SmallPage } from '@nimiq/vue-components';
 import Loader from '@/components/Loader.vue';
 import WalletInfoCollector from '@/lib/WalletInfoCollector';
 import KeyguardClient from '@nimiq/keyguard-client';
+import { WalletCollectionResult } from '../lib/WalletInfoCollector';
 
 @Component({components: {Loader, SmallPage}})
 export default class LoginSuccess extends Vue {
@@ -39,57 +40,92 @@ export default class LoginSuccess extends Vue {
     private result: Account[] | null = null;
 
     private async mounted() {
-        // TODO: Handle import of both a legacy and bip39 key!
-        this.keyguardResult.map(async (keyResult) => {
-            // The Keyguard always returns (at least) one derived Address,
-            const keyguardResultAccounts = keyResult.addresses.map((addressObj) => ({
-                address: new Nimiq.Address(addressObj.address).toUserFriendlyAddress(),
-                path: addressObj.keyPath,
-            }));
+        const collectionResults: WalletCollectionResult[] = [];
 
-            let tryCount = 0;
-            while (true) {
-                try {
-                    tryCount += 1;
-                    const { walletInfo, receiptsError } = await WalletInfoCollector.collectWalletInfo(
-                        keyResult.keyType,
-                        keyResult.keyId,
-                        keyguardResultAccounts,
-                    );
+        await Promise.all(
+            this.keyguardResult.map(async (keyResult) => {
+                // The Keyguard always returns (at least) one derived Address,
+                const keyguardResultAccounts = keyResult.addresses.map((addressObj) => ({
+                    address: new Nimiq.Address(addressObj.address).toUserFriendlyAddress(),
+                    path: addressObj.keyPath,
+                }));
 
-                    if (receiptsError) {
-                        this.receiptsError = receiptsError;
+                let tryCount = 0;
+                while (true) {
+                    try {
+                        tryCount += 1;
+                        const collectionResult = await WalletInfoCollector.collectWalletInfo(
+                            keyResult.keyType,
+                            keyResult.keyId,
+                            keyguardResultAccounts,
+                        );
+
+                        if (collectionResult.receiptsError) {
+                            this.receiptsError = collectionResult.receiptsError;
+                        }
+
+                        collectionResult.walletInfo.fileExported = collectionResult.walletInfo.fileExported
+                            || keyResult.fileExported;
+                        collectionResult.walletInfo.wordsExported = collectionResult.walletInfo.wordsExported
+                            || keyResult.wordsExported;
+
+                        collectionResults.push(collectionResult);
+
+                        this.retrievalFailed = false;
+                        break;
+                    } catch (e) {
+                        this.retrievalFailed = true;
+                        if (tryCount >= 5) throw e;
                     }
-
-                    walletInfo.fileExported = walletInfo.fileExported || keyResult.fileExported;
-                    walletInfo.wordsExported = walletInfo.wordsExported || keyResult.wordsExported;
-
-                    await WalletStore.Instance.put(walletInfo);
-                    this.walletInfos.push(walletInfo);
-
-                    this.retrievalFailed = false;
-                    this.done();
-                    break;
-                } catch (e) {
-                    this.retrievalFailed = true;
-                    if (tryCount >= 5) throw e;
                 }
+            }),
+        );
+
+        // In case there is only one returned Account it is always added.
+        // WalletType.LEDGER always returns one Account, hence does not need special treatment in the other cases.
+        let condition: (collectionResult: WalletCollectionResult) => boolean = (collectionResult) => true;
+        if (collectionResults.length > 1) {
+            if (collectionResults.some((walletInfo) => walletInfo.hasHistoryOrBalance)) {
+                // In case there is more than one account returned and at least one saw activity in the past
+                // add the accounts with activity while discarding the others.
+                condition = (collectionResult) => collectionResult.hasHistoryOrBalance;
+            } else {
+                // In case of more than one returned account but none saw activity in the past
+                // look for the BIP39 account and add it while discarding the others.
+                condition = (collectionResult) => collectionResult.walletInfo.type === WalletType.BIP39;
             }
-        });
+        }
+
+        await Promise.all (
+            collectionResults.map( async (collectionResult, index) => {
+                if (condition(collectionResult)) {
+                    await WalletStore.Instance.put(collectionResult.walletInfo);
+                    this.walletInfos.push(collectionResult.walletInfo);
+                    collectionResult.releaseKey(false);
+                } else {
+                    collectionResult.releaseKey(true);
+                }
+            }),
+        );
+
+        this.done();
     }
 
     private done() {
         if (!this.walletInfos.length) throw new Error('WalletInfo not ready.');
-        this.result = [{
-            accountId: this.walletInfos[0].id,
-            label: this.walletInfos[0].label,
-            type: this.walletInfos[0].type,
-            fileExported: this.walletInfos[0].fileExported,
-            wordsExported: this.walletInfos[0].wordsExported,
-            addresses: Array.from(this.walletInfos[0].accounts.values())
-                .map((addressInfo) => addressInfo.toAddressType()),
-            contracts: this.walletInfos[0].contracts.map((contract) => contract.toContractType()),
-        }];
+        this.result = [];
+        for (const walletInfo of this.walletInfos) {
+            this.result.push({
+                accountId: walletInfo.id,
+                label: walletInfo.label,
+                type: walletInfo.type,
+                fileExported: walletInfo.fileExported,
+                wordsExported: walletInfo.wordsExported,
+                addresses: Array.from(walletInfo.accounts.values())
+                    .map((addressInfo) => addressInfo.toAddressType()),
+                contracts: walletInfo.contracts.map((contract) => contract.toContractType()),
+            });
+        }
 
         if (this.receiptsError) {
             this.title = 'Your addresses may be\nincomplete.';

--- a/src/views/SignupLedger.vue
+++ b/src/views/SignupLedger.vue
@@ -90,13 +90,14 @@ export default class SignupLedger extends Vue {
             try {
                 tryCount += 1;
                 // triggers loading and connecting states in LedgerUi if applicable
-                await WalletInfoCollector.collectWalletInfo(
+                const { releaseKey } = await WalletInfoCollector.collectWalletInfo(
                     WalletType.LEDGER,
                     /* keyId */ '',
                     /* initialAccounts */ [],
                     (walletInfo, currentlyCheckedAccounts) =>
                         this._onWalletInfoUpdate(walletInfo, currentlyCheckedAccounts),
                 );
+                await releaseKey();
                 this.failedFetchingAccounts = false;
                 break;
             } catch (e) {


### PR DESCRIPTION
This PR updates `LoginSuccess` and `WalletInfoCollector`. 

Single returned Accounts still get added as usual. 
For multiple returned Accounts, if there are some which have either a balance or a transaction history, only those will be added. Otherwise none of the Accounts was previously used and then only the newest AccountType (BIP39) will be added.

The accounts which did not got added, will also correctly be released in Keyguard.

needs nimiq/keyguard-next#297

resolves #147 