### PR TITLE
Wallet info collector refactor

### DIFF
--- a/src/views/LoginSuccess.vue
+++ b/src/views/LoginSuccess.vue
@@ -54,13 +54,23 @@ export default class LoginSuccess extends Vue {
                 while (true) {
                     try {
                         tryCount += 1;
-                        const collectionResult = await WalletInfoCollector.collectWalletInfo(
-                            keyResult.keyType,
-                            keyResult.keyId,
-                            keyguardResultAccounts,
-                            undefined,
-                            this.keyguardResult.length > 1,
-                        );
+                        let collectionResult: WalletCollectionResult;
+                        if (keyResult.keyType === WalletType.BIP39) {
+                            collectionResult = await WalletInfoCollector.collectLedgerOrBip39WalletInfo(
+                                WalletType.BIP39,
+                                keyResult.keyId,
+                                keyguardResultAccounts,
+                                undefined,
+                                this.keyguardResult.length === 1,
+                            );
+                        } else {
+                            collectionResult = await WalletInfoCollector.collectLegacyWalletInfo(
+                                keyResult.keyId,
+                                keyguardResultAccounts[0],
+                                undefined,
+                                this.keyguardResult.length === 1,
+                            );
+                        }
 
                         if (collectionResult.receiptsError) {
                             this.receiptsError = collectionResult.receiptsError;
@@ -98,7 +108,7 @@ export default class LoginSuccess extends Vue {
         }
 
         await Promise.all (
-            collectionResults.map( async (collectionResult) => {
+            collectionResults.map(async (collectionResult) => {
                 if (keepWalletCondition(collectionResult)) {
                     await WalletStore.Instance.put(collectionResult.walletInfo);
                     this.walletInfos.push(collectionResult.walletInfo);

--- a/src/views/LoginSuccess.vue
+++ b/src/views/LoginSuccess.vue
@@ -25,7 +25,7 @@ import { SmallPage } from '@nimiq/vue-components';
 import Loader from '@/components/Loader.vue';
 import WalletInfoCollector from '@/lib/WalletInfoCollector';
 import KeyguardClient from '@nimiq/keyguard-client';
-import { WalletCollectionResult } from '../lib/WalletInfoCollector';
+import { WalletCollectionResultKeyguard } from '../lib/WalletInfoCollector';
 
 @Component({components: {Loader, SmallPage}})
 export default class LoginSuccess extends Vue {
@@ -40,7 +40,7 @@ export default class LoginSuccess extends Vue {
     private result: Account[] | null = null;
 
     private async mounted() {
-        const collectionResults: WalletCollectionResult[] = [];
+        const collectionResults: WalletCollectionResultKeyguard[] = [];
 
         await Promise.all(
             this.keyguardResult.map(async (keyResult) => {
@@ -54,10 +54,9 @@ export default class LoginSuccess extends Vue {
                 while (true) {
                     try {
                         tryCount += 1;
-                        let collectionResult: WalletCollectionResult;
+                        let collectionResult: WalletCollectionResultKeyguard;
                         if (keyResult.keyType === WalletType.BIP39) {
-                            collectionResult = await WalletInfoCollector.collectLedgerOrBip39WalletInfo(
-                                WalletType.BIP39,
+                            collectionResult = await WalletInfoCollector.collectBip39WalletInfo(
                                 keyResult.keyId,
                                 keyguardResultAccounts,
                                 undefined,
@@ -94,7 +93,7 @@ export default class LoginSuccess extends Vue {
         );
 
         // In case there is only one returned Account it is always added.
-        let keepWalletCondition: (collectionResult: WalletCollectionResult) => boolean = (collectionResult) => true;
+        let keepWalletCondition: (collectionResult: WalletCollectionResultKeyguard) => boolean = () => true;
         if (collectionResults.length > 1) {
             if (collectionResults.some((walletInfo) => walletInfo.hasActivity)) {
                 // In case there is more than one account returned and at least one saw activity in the past

--- a/src/views/SignupLedger.vue
+++ b/src/views/SignupLedger.vue
@@ -90,15 +90,12 @@ export default class SignupLedger extends Vue {
             try {
                 tryCount += 1;
                 // triggers loading and connecting states in LedgerUi if applicable
-                const { releaseKey } = await WalletInfoCollector.collectLedgerOrBip39WalletInfo(
-                    WalletType.LEDGER,
-                    /* keyId */ '',
+                await WalletInfoCollector.collectLedgerWalletInfo(
                     /* initialAccounts */ [],
                     (walletInfo, currentlyCheckedAccounts) =>
                         this._onWalletInfoUpdate(walletInfo, currentlyCheckedAccounts),
                     /* skipActivityCheck */ true,
                 );
-                await releaseKey();
                 this.failedFetchingAccounts = false;
                 break;
             } catch (e) {

--- a/src/views/SignupLedger.vue
+++ b/src/views/SignupLedger.vue
@@ -90,12 +90,13 @@ export default class SignupLedger extends Vue {
             try {
                 tryCount += 1;
                 // triggers loading and connecting states in LedgerUi if applicable
-                const { releaseKey } = await WalletInfoCollector.collectWalletInfo(
+                const { releaseKey } = await WalletInfoCollector.collectLedgerOrBip39WalletInfo(
                     WalletType.LEDGER,
                     /* keyId */ '',
                     /* initialAccounts */ [],
                     (walletInfo, currentlyCheckedAccounts) =>
                         this._onWalletInfoUpdate(walletInfo, currentlyCheckedAccounts),
+                    /* skipActivityCheck */ true,
                 );
                 await releaseKey();
                 this.failedFetchingAccounts = false;


### PR DESCRIPTION
- Split collection for legacy / Bip39 / ledger accounts into separate methods
- Join logic for vesting contract detection into a single method
- Make sure the network is initialized before requesting transaction histories
- Remove the checkLegacyActivity flag on _initializeDependencies
- Performance improvements:
    - don't create keyguard client if not needed
    - don't request balance / transaction history for initial accounts if not needed

Not always requesting the balance for the initial accounts implies that the
WalletInfoCollector now does not guarantee anymore to return fully updated balances.