### PR TITLE
Fix paths for subrequest refreshs

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "postinstall": "cd client && yarn"
     },
     "dependencies": {
-        "@nimiq/browser-warning": "^0.3.0",
+        "@nimiq/browser-warning": "^0.4.0",
         "@nimiq/iqons": "^1.4.4",
         "@nimiq/keyguard-client": "^0.4.3",
         "@nimiq/ledgerjs": "https://github.com/nimiq/ledger-api.git",

--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <script type="text/javascript" src="/browser-warning.js" defer></script>
-    <script src="https://cdn.nimiq-testnet.com/web-offline.js"></script>
+    <script src="https://cdn.nimiq-testnet.com/v1.4.3/web-offline.js"></script>
     <title>Nimiq Accounts Manager</title>
     <link href="/blocking.css" rel="stylesheet">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">

--- a/public/index.html
+++ b/public/index.html
@@ -5,10 +5,10 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <script type="text/javascript" src="browser-warning.js" defer></script>
+    <script type="text/javascript" src="/browser-warning.js" defer></script>
     <script src="https://cdn.nimiq-testnet.com/web-offline.js"></script>
     <title>Nimiq Accounts Manager</title>
-    <link href="blocking.css" rel="stylesheet">
+    <link href="/blocking.css" rel="stylesheet">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
 </head>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -680,10 +680,10 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@nimiq/browser-warning@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@nimiq/browser-warning/-/browser-warning-0.3.0.tgz#445e091045f3f42ac47ac6d8f62b484869e4f1d8"
-  integrity sha512-EGvPTgeAHc6gRSGQavG0RLVgp1nWZFoxkCtcX8a+E1+gTSl41wa5d8+56O5knq/bQoLjTl3EHf0+95PpGycx0Q==
+"@nimiq/browser-warning@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@nimiq/browser-warning/-/browser-warning-0.4.0.tgz#82f9c88e75f85fbaab838e970d1f27ad506beefd"
+  integrity sha512-7NEqSzsYwNvLM4KpnGtmSppVJju0HWjrHtbRMWefaXDfugM6bCbMqVLc112Bm88EefPdISj1cTr0pcyZZOCzuQ==
 
 "@nimiq/core-types@^1.0.1":
   version "1.0.1"


### PR DESCRIPTION
make browser-warning.js and blocking.css paths absolute; update @nimiq/browser-warning, fix Nimiq version